### PR TITLE
Add admin dashboard route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
+import AdminRoute from './components/AdminRoute';
 import Layout from './components/Layout/Layout';
 import Auth from './pages/Auth';
 import Dashboard from './pages/Dashboard';
@@ -11,6 +12,7 @@ import Favorites from './pages/Favorites';
 import Profile from './pages/Profile';
 import Settings from './pages/Settings';
 import Payment from './pages/Payment';
+import AdminDashboard from './pages/AdminDashboard';
 
 function App() {
   return (
@@ -33,6 +35,14 @@ function App() {
             <Route path="profile" element={<Profile />} />
             <Route path="payment" element={<Payment />} />
             <Route path="settings" element={<Settings />} />
+            <Route
+              path="admin"
+              element={
+                <AdminRoute>
+                  <AdminDashboard />
+                </AdminRoute>
+              }
+            />
             <Route path="" element={<Navigate to="/dashboard" replace />} />
           </Route>
         </Routes>

--- a/src/components/AdminRoute.tsx
+++ b/src/components/AdminRoute.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+interface AdminRouteProps {
+  children: React.ReactNode;
+}
+
+const AdminRoute: React.FC<AdminRouteProps> = ({ children }) => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-teal-500" />
+      </div>
+    );
+  }
+
+  if (!user || !user.isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AdminRoute;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -5,11 +5,12 @@ import {
   User, 
   Heart, 
   ShoppingBag, 
-  Sparkles, 
+  Sparkles,
   Home,
   Settings,
   LogOut,
-  TrendingUp
+  TrendingUp,
+  ShieldCheck
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 
@@ -20,7 +21,7 @@ interface SidebarProps {
 
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const location = useLocation();
-  const { logout } = useAuth();
+  const { user, logout } = useAuth();
 
   const menuItems = [
     { icon: Home, label: 'Início', path: '/dashboard' },
@@ -30,6 +31,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
     { icon: User, label: 'Perfil', path: '/profile' },
     { icon: TrendingUp, label: 'Progresso', path: '/progress' },
     { icon: Sparkles, label: 'Novidades', path: '/programs' },
+    ...(user?.isAdmin ? [{ icon: ShieldCheck, label: 'Admin', path: '/admin' }] : []),
   ];
 
   const isActive = (path: string) => location.pathname === path;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -9,12 +9,15 @@ import {
 } from 'firebase/auth';
 import { auth } from '../firebase';
 
+const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || 'admin@seuauge.com';
+
 interface User {
   id: string;
   email: string;
   name: string;
   avatar?: string;
   isPremium: boolean;
+  isAdmin: boolean;
 }
 
 interface AuthContextType {
@@ -48,6 +51,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
           name: firebaseUser.displayName || '',
           avatar: firebaseUser.photoURL || undefined,
           isPremium: false,
+          isAdmin: firebaseUser.email === ADMIN_EMAIL,
         };
         setUser(mapped);
       } else {
@@ -69,6 +73,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         name: firebaseUser.displayName || '',
         avatar: firebaseUser.photoURL || undefined,
         isPremium: false,
+        isAdmin: firebaseUser.email === ADMIN_EMAIL,
       };
       setUser(mapped);
     } catch (err) {
@@ -89,6 +94,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         name,
         avatar: firebaseUser.photoURL || undefined,
         isPremium: false,
+        isAdmin: firebaseUser.email === ADMIN_EMAIL,
       };
       setUser(mapped);
     } catch (err) {

--- a/src/pages/AdminDashboard.tsx
+++ b/src/pages/AdminDashboard.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Users, DollarSign, ShoppingBag } from 'lucide-react';
+
+const AdminDashboard: React.FC = () => {
+  // Esses valores podem ser obtidos do banco de dados futuramente
+  const stats = [
+    { icon: Users, label: 'Usuários Ativos', value: 1200, color: 'bg-teal-600' },
+    { icon: DollarSign, label: 'Receita Mensal', value: 'R$ 15.800', color: 'bg-emerald-600' },
+    { icon: ShoppingBag, label: 'Vendas', value: 320, color: 'bg-cyan-600' },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold text-white">Painel Administrativo</h1>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        {stats.map((stat, index) => {
+          const Icon = stat.icon;
+          return (
+            <div key={index} className="bg-slate-800 rounded-lg p-6 flex items-center space-x-4">
+              <div className={`w-12 h-12 ${stat.color} rounded-full flex items-center justify-center`}>
+                <Icon className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <div className="text-xl font-bold text-white">{stat.value}</div>
+                <div className="text-sm text-slate-400">{stat.label}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default AdminDashboard;


### PR DESCRIPTION
## Summary
- extend AuthContext with basic admin support
- create AdminRoute and dashboard page
- show admin link in sidebar if user is admin
- wire admin route in router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630e0e9d4c8332906729a54dac0944