### PR TITLE
Implement profile photo upload

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   User as FirebaseUser,
 } from 'firebase/auth';
 import { auth } from '../firebase';
+import { updateUserProfile, UpdateUserInput } from '../services/user';
 import { getPlanFromToken } from '../services/plan';
 
 const ADMIN_EMAIL = import.meta.env.VITE_ADMIN_EMAIL || 'admin@seuauge.com';
@@ -27,6 +28,7 @@ interface AuthContextType {
   login: (email: string, password: string) => Promise<void>;
   register: (email: string, password: string, name: string) => Promise<void>;
   logout: () => void;
+  updateUser: (data: UpdateUserInput) => Promise<void>;
   loading: boolean;
 }
 
@@ -99,11 +101,25 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(null);
   };
 
+  const updateUser = async (data: UpdateUserInput) => {
+    try {
+      await updateUserProfile(data);
+      if (auth.currentUser) {
+        const mapped = await mapFirebaseUser(auth.currentUser);
+        setUser(mapped);
+      }
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  };
+
   const value = {
     user,
     login,
     register,
     logout,
+    updateUser,
     loading
   };
 

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyDttKYZ1bQEzEzK43y1qQo8z9g3cG-N2Ss",
@@ -13,7 +15,9 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const db = getFirestore(app);
+const storage = getStorage(app);
 
-export { auth }; // 👈 Isso que estava faltando
+export { auth, db, storage };
 
 export default app;

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -21,6 +21,9 @@ const Payment: React.FC = () => {
           <span className="font-medium">Boleto</span>
         </div>
       </div>
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        O pagamento será realizado em um ambiente externo seguro.
+      </p>
       <Link to="/store" className="inline-flex items-center text-teal-600 hover:underline">
         <ArrowLeft className="w-4 h-4 mr-2" /> Voltar para a loja
       </Link>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,18 +1,31 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { User, Camera, Edit3, Save, X } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 
 const Profile: React.FC = () => {
-  const { user } = useAuth();
+  const { user, updateUser } = useAuth();
   const [isEditing, setIsEditing] = useState(false);
   const [formData, setFormData] = useState({
     name: user?.name || '',
     email: user?.email || '',
   });
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
 
-  const handleSave = () => {
-    // Aqui você normalmente atualizaria os dados do usuário
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0];
+    if (selected) {
+      setFile(selected);
+      setPreview(URL.createObjectURL(selected));
+    }
+  };
+
+  const handleSave = async () => {
+    await updateUser({ name: formData.name, email: formData.email, file });
     setIsEditing(false);
+    setFile(null);
+    setPreview(null);
   };
 
   const handleCancel = () => {
@@ -20,6 +33,8 @@ const Profile: React.FC = () => {
       name: user?.name || '',
       email: user?.email || '',
     });
+    setFile(null);
+    setPreview(null);
     setIsEditing(false);
   };
 
@@ -63,16 +78,25 @@ const Profile: React.FC = () => {
           {/* Avatar */}
           <div className="relative">
             <div className="w-32 h-32 rounded-full overflow-hidden bg-gradient-to-r from-teal-500 to-emerald-500 flex items-center justify-center">
-              {user?.avatar ? (
+              {preview ? (
+                <img src={preview} alt="preview" className="w-full h-full object-cover" />
+              ) : user?.avatar ? (
                 <img src={user.avatar} alt={user.name} className="w-full h-full object-cover" />
               ) : (
                 <User className="w-16 h-16 text-white" />
               )}
             </div>
             {isEditing && (
-              <button className="absolute bottom-0 right-0 w-10 h-10 bg-teal-600 hover:bg-teal-700 rounded-full flex items-center justify-center text-white transition-colors">
-                <Camera className="w-5 h-5" />
-              </button>
+              <>
+                <button
+                  type="button"
+                  onClick={() => fileRef.current?.click()}
+                  className="absolute bottom-0 right-0 w-10 h-10 bg-teal-600 hover:bg-teal-700 rounded-full flex items-center justify-center text-white transition-colors"
+                >
+                  <Camera className="w-5 h-5" />
+                </button>
+                <input ref={fileRef} type="file" className="hidden" accept="image/*" onChange={handleFileChange} />
+              </>
             )}
           </div>
 

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,5 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyDttKYZ1bQEzEzK43y1qQo8z9g3cG-N2Ss",
@@ -12,7 +14,9 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const db = getFirestore(app);
+const storage = getStorage(app);
 
-export { auth }; // 👈 Isso que estava faltando
+export { auth, db, storage };
 
 export default app;


### PR DESCRIPTION
## Summary
- add Firestore and Storage to firebase config
- create user service to update profile
- expose updateUser in auth context
- allow photo upload on profile page
- clarify external payment processing

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68666d15868483329e166c2fe54010ae