### PR TITLE
Implement plan purchase flow

### DIFF
--- a/README2.md
+++ b/README2.md
@@ -1,0 +1,21 @@
+# Fluxo de Aquisição de Planos
+
+Este documento descreve o processo de escolha e compra de planos dentro do **Seu Auge**.
+
+## Tela de Planos
+
+1. Acesse `Planos` no menu lateral.
+2. São exibidos os planos A, B e C, com preço e lista de benefícios.
+3. O plano atual do usuário é destacado. Opções de upgrade aparecem somente para planos superiores.
+4. Ao clicar em **Adquirir**, o usuário é levado para a tela de pagamento (`/payment?plan=X`).
+
+## Pagamento
+
+1. Na tela de pagamento são apresentadas as formas de pagamento (PIX, cartão e boleto).
+2. O botão **Realizar Pagamento** abre o gateway externo definido em `VITE_PAYMENT_URL`.
+3. Após concluir o pagamento, o usuário retorna e clica em **Já paguei**.
+4. O sistema registra o novo plano via endpoint `/plan`, atualiza o token do Firebase e redireciona para a tela de planos.
+
+## Liberação de Conteúdo
+
+Com o token atualizado, o `PlanGuard` libera o acesso a páginas restritas conforme o plano adquirido. Planos superiores têm acesso a mais vídeos e funcionalidades.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Favorites from './pages/Favorites';
 import Profile from './pages/Profile';
 import Settings from './pages/Settings';
 import Payment from './pages/Payment';
+import Plans from './pages/Plans';
 import AdminDashboard from './pages/AdminDashboard';
 
 function App() {
@@ -41,6 +42,7 @@ function App() {
             <Route path="store" element={<Store />} />
             <Route path="favorites" element={<Favorites />} />
             <Route path="profile" element={<Profile />} />
+            <Route path="plans" element={<Plans />} />
             <Route path="payment" element={<Payment />} />
             <Route path="settings" element={<Settings />} />
             <Route

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -27,6 +27,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
     { icon: Home, label: 'Início', path: '/dashboard' },
     { icon: Play, label: 'Vídeos', path: '/videos' },
     { icon: ShoppingBag, label: 'Loja', path: '/store' },
+    { icon: Sparkles, label: 'Planos', path: '/plans' },
     { icon: Heart, label: 'Favoritos', path: '/favorites' },
     { icon: TrendingUp, label: 'Progresso', path: '/progress' },
     { icon: Sparkles, label: 'Novidades', path: '/programs' },

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -30,6 +30,7 @@ interface AuthContextType {
   register: (email: string, password: string, name: string) => Promise<void>;
   logout: () => void;
   updateUser: (data: UpdateUserInput) => Promise<void>;
+  refreshPlan: () => Promise<void>;
   loading: boolean;
 }
 
@@ -118,12 +119,21 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
+  const refreshPlan = async () => {
+    if (!auth.currentUser) return;
+    const newPlan = await getPlanFromToken(true);
+    setUser((prev) =>
+      prev ? { ...prev, plan: newPlan, isPremium: newPlan !== 'A' } : prev
+    );
+  };
+
   const value = {
     user,
     login,
     register,
     logout,
     updateUser,
+    refreshPlan,
     loading
   };
 

--- a/src/data/plans.ts
+++ b/src/data/plans.ts
@@ -1,0 +1,38 @@
+export interface Plan {
+  id: 'A' | 'B' | 'C';
+  name: string;
+  price: string;
+  features: string[];
+}
+
+export const PLANS: Plan[] = [
+  {
+    id: 'A',
+    name: 'Plano A',
+    price: 'Gratuito',
+    features: [
+      'Acesso limitado aos vídeos gratuitos',
+      'Cadastro básico na plataforma',
+    ],
+  },
+  {
+    id: 'B',
+    name: 'Plano B',
+    price: 'R$ 29,90 / mês',
+    features: [
+      'Todos os vídeos de saúde',
+      'Conteúdos exclusivos semanais',
+      'Suporte prioritário',
+    ],
+  },
+  {
+    id: 'C',
+    name: 'Plano C',
+    price: 'R$ 49,90 / mês',
+    features: [
+      'Todos os benefícios do Plano B',
+      'Descontos especiais na loja',
+      'Acesso antecipado a lançamentos',
+    ],
+  },
+];

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -1,16 +1,29 @@
 // Tela responsável por iniciar o fluxo de pagamento fora da plataforma
 import React from 'react';
-import { CreditCard, Smartphone, Barcode, ArrowLeft, ExternalLink } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { CreditCard, Smartphone, Barcode, ArrowLeft, ExternalLink, Check } from 'lucide-react';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { updateUserPlan } from '../services/plan';
+import { useAuth } from '../contexts/AuthContext';
 
 // URL do provedor externo de pagamento
 const PAYMENT_URL = import.meta.env.VITE_PAYMENT_URL || 'https://pagamento.exemplo.com';
 
 const Payment: React.FC = () => {
-  // Redireciona o usuário para o provedor externo de pagamento
+  const navigate = useNavigate();
+  const { refreshPlan } = useAuth();
+  const [search] = useSearchParams();
+  const selectedPlan = search.get('plan');
+
   const handlePay = () => {
     console.log('Redirecionando para o pagamento externo');
     window.open(PAYMENT_URL, '_blank');
+  };
+
+  const handleConfirm = async () => {
+    if (!selectedPlan) return;
+    await updateUserPlan(selectedPlan);
+    await refreshPlan();
+    navigate('/plans');
   };
 
   return (
@@ -39,6 +52,12 @@ const Payment: React.FC = () => {
         className="inline-flex items-center px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-lg"
       >
         <ExternalLink className="w-4 h-4 mr-2" /> Realizar Pagamento
+      </button>
+      <button
+        onClick={handleConfirm}
+        className="inline-flex items-center px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg"
+      >
+        <Check className="w-4 h-4 mr-2" /> Já paguei
       </button>
       <Link to="/store" className="inline-flex items-center text-teal-600 hover:underline">
         <ArrowLeft className="w-4 h-4 mr-2" /> Voltar para a loja

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PLANS, Plan } from '../data/plans';
+import usePlan from '../hooks/usePlan';
+
+const Plans: React.FC = () => {
+  const navigate = useNavigate();
+  const { plan } = usePlan();
+
+  const canUpgrade = (target: Plan) => {
+    if (!plan) return true;
+    const order = ['A', 'B', 'C'];
+    return order.indexOf(target.id) > order.indexOf(plan);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Planos</h1>
+      <p className="text-slate-600 dark:text-slate-400">
+        Seu plano atual: <span className="font-semibold">{plan || 'A'}</span>
+      </p>
+      <div className="grid md:grid-cols-3 gap-6">
+        {PLANS.map((p) => (
+          <div key={p.id} className="bg-slate-100 dark:bg-slate-800 p-6 rounded-xl flex flex-col">
+            <h2 className="text-xl font-bold mb-2 text-slate-900 dark:text-white">
+              {p.name}
+            </h2>
+            <span className="text-teal-600 dark:text-teal-400 mb-4 font-medium">
+              {p.price}
+            </span>
+            <ul className="flex-1 space-y-1 text-sm mb-4 list-disc list-inside text-slate-700 dark:text-slate-300">
+              {p.features.map((f) => (
+                <li key={f}>{f}</li>
+              ))}
+            </ul>
+            {plan === p.id ? (
+              <button className="w-full bg-slate-300 dark:bg-slate-700 text-slate-500 dark:text-slate-400 py-2 rounded-lg cursor-not-allowed" disabled>
+                Seu plano atual
+              </button>
+            ) : (
+              <button
+                onClick={() => navigate(`/payment?plan=${p.id}`)}
+                disabled={!canUpgrade(p)}
+                className={`w-full py-2 rounded-lg text-white ${
+                  canUpgrade(p)
+                    ? 'bg-teal-600 hover:bg-teal-700'
+                    : 'bg-slate-400 cursor-not-allowed'
+                }`}
+              >
+                {canUpgrade(p) ? 'Adquirir' : 'Indisponível'}
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Plans;

--- a/src/services/plan.ts
+++ b/src/services/plan.ts
@@ -1,4 +1,5 @@
 import { auth } from '../firebase';
+import api from './api';
 
 export async function getPlanFromToken(forceRefresh = false): Promise<string | null> {
   const currentUser = auth.currentUser;
@@ -8,3 +9,9 @@ export async function getPlanFromToken(forceRefresh = false): Promise<string | n
   return plan ?? null;
 }
 
+export async function updateUserPlan(plan: string): Promise<void> {
+  await api('/plan', {
+    method: 'POST',
+    body: JSON.stringify({ plan }),
+  });
+}


### PR DESCRIPTION
## Summary
- add description of plan purchase flow in `README2.md`
- provide dataset with plan details
- add Plans page and route
- update sidebar navigation
- implement payment confirmation logic
- support plan refresh in auth context

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866b484cb688332a57e70dc74e8800d