### PR TITLE
Fix videos route access and profile updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,6 @@ import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-d
 import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
-import PlanGuard from './components/PlanGuard';
 import Layout from './components/Layout/Layout';
 import Auth from './pages/Auth';
 import Dashboard from './pages/Dashboard';
@@ -31,14 +30,7 @@ function App() {
             }
           >
             <Route path="dashboard" element={<Dashboard />} />
-            <Route
-              path="videos"
-              element={
-                <PlanGuard allowedPlans={['B', 'C']}>
-                  <Videos />
-                </PlanGuard>
-              }
-            />
+            <Route path="videos" element={<Videos />} />
             <Route path="store" element={<Store />} />
             <Route path="favorites" element={<Favorites />} />
             <Route path="profile" element={<Profile />} />

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -22,18 +22,19 @@ export async function updateUserProfile({ name, email, file }: UpdateUserInput) 
 
   await updateProfile(auth.currentUser, {
     displayName: name,
-    photoURL,
+    photoURL: photoURL ?? null,
   });
 
   if (auth.currentUser.email !== email) {
     await updateEmail(auth.currentUser, email);
   }
 
-  await setDoc(
-    doc(db, 'users', auth.currentUser.uid),
-    { name, email, avatar: photoURL },
-    { merge: true }
-  );
+  const data: Record<string, unknown> = { name, email };
+  if (photoURL !== undefined) {
+    data.avatar = photoURL;
+  }
+
+  await setDoc(doc(db, 'users', auth.currentUser.uid), data, { merge: true });
 
   return photoURL;
 }


### PR DESCRIPTION
## Summary
- allow all users to access the videos page
- fix avatar update logic so Firestore doesn't get undefined values

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866bbd6c90c8332b69231f0f1dccfec