### PR TITLE
Adjust dashboard layout and add purchased product modal

### DIFF
--- a/src/components/Products/PurchasedProductCard.tsx
+++ b/src/components/Products/PurchasedProductCard.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ArrowRight } from 'lucide-react';
+import type { Product } from '../../stores/cartStore';
+
+interface PurchasedProductCardProps {
+  product: Product;
+  onSelect: (product: Product) => void;
+}
+
+const PurchasedProductCard: React.FC<PurchasedProductCardProps> = ({ product, onSelect }) => {
+  return (
+    <div className="group bg-slate-800 rounded-lg overflow-hidden hover:transform hover:scale-105 transition-all duration-300 hover:shadow-xl hover:shadow-teal-500/10">
+      <img src={product.image} alt={product.name} className="w-full h-48 object-cover" />
+      <div className="p-4 flex flex-col space-y-3">
+        <h3 className="font-semibold text-white line-clamp-2">{product.name}</h3>
+        <button
+          onClick={() => onSelect(product)}
+          className="mt-auto inline-flex items-center justify-center bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+        >
+          Acessar
+          <ArrowRight className="w-4 h-4 ml-2" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PurchasedProductCard;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Play, ShoppingBag, TrendingUp, Clock } from 'lucide-react';
-import VideoCard from '../components/Videos/VideoCard';
 import ProductCard from '../components/Products/ProductCard';
-import { mockVideos, mockProducts } from '../data/mockData';
+import PurchasedProductCard from '../components/Products/PurchasedProductCard';
+import ProductModal from '../components/Products/ProductModal';
+import { mockProducts } from '../data/mockData';
 import { useAuth } from '../contexts/AuthContext';
+import type { Product } from '../stores/cartStore';
 
 const Dashboard: React.FC = () => {
   const { user } = useAuth();
   
-  const featuredVideos = mockVideos.slice(0, 4);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+
   const featuredProducts = mockProducts.slice(0, 4);
-  const continueWatching = mockVideos.slice(2, 4);
+  const purchasedProducts = mockProducts.slice(2, 6);
 
   const stats = [
     { icon: Play, label: 'Vídeos Assistidos', value: '47', color: 'bg-teal-600' },
@@ -69,19 +72,6 @@ const Dashboard: React.FC = () => {
         })}
       </div>
 
-      {/* Featured Health Videos */}
-      <section>
-        <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-white">Vídeos de Saúde em Destaque</h2>
-          <button className="text-teal-400 hover:text-teal-300 font-medium">Ver Todos</button>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {featuredVideos.map((video) => (
-            <VideoCard key={video.id} video={video} />
-          ))}
-        </div>
-      </section>
-
       {/* Health Products Store */}
       <section>
         <div className="flex items-center justify-between mb-6">
@@ -95,27 +85,21 @@ const Dashboard: React.FC = () => {
         </div>
       </section>
 
-      {/* Continue Watching */}
+      {/* Purchased Products */}
       <section>
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-2xl font-bold text-white">Continuar Assistindo</h2>
+          <h2 className="text-2xl font-bold text-white">Produtos Adquiridos</h2>
           <button className="text-teal-400 hover:text-teal-300 font-medium">Ver Todos</button>
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {continueWatching.map((video) => (
-            <div key={video.id} className="relative">
-              <VideoCard video={video} />
-              {/* Progress bar */}
-              <div className="absolute bottom-0 left-0 right-0 h-1 bg-slate-700">
-                <div 
-                  className="h-full bg-teal-500" 
-                  style={{ width: `${Math.random() * 70 + 10}%` }}
-                />
-              </div>
-            </div>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {purchasedProducts.map((product) => (
+            <PurchasedProductCard key={product.id} product={product} onSelect={setSelectedProduct} />
           ))}
         </div>
       </section>
+      {selectedProduct && (
+        <ProductModal product={selectedProduct} onClose={() => setSelectedProduct(null)} />
+      )}
     </div>
   );
 };

--- a/src/pages/Videos.tsx
+++ b/src/pages/Videos.tsx
@@ -7,6 +7,8 @@ const Videos: React.FC = () => {
   const [selectedCategory, setSelectedCategory] = useState('Todos');
   const [selectedType, setSelectedType] = useState('Todos');
 
+  const continueWatching = mockVideos.slice(0, 3);
+
   const categories = ['Todos', 'Yoga', 'Fitness', 'Nutrição', 'Meditação', 'Pilates', 'Bem-estar'];
   const types = ['Todos', 'Gratuito', 'Premium'];
 
@@ -31,6 +33,25 @@ const Videos: React.FC = () => {
           {filteredVideos.length} vídeos encontrados
         </div>
       </div>
+
+      {continueWatching.length > 0 && (
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-white">Continuar Assistindo</h2>
+            <button className="text-teal-400 hover:text-teal-300 font-medium">Ver Todos</button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {continueWatching.map((video) => (
+              <div key={video.id} className="relative">
+                <VideoCard video={video} />
+                <div className="absolute bottom-0 left-0 right-0 h-1 bg-slate-700">
+                  <div className="h-full bg-teal-500" style={{ width: `${Math.random() * 70 + 10}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
 
       {/* Filters */}
       <div className="bg-slate-800 rounded-lg p-6">


### PR DESCRIPTION
## Summary
- add PurchasedProductCard component
- replace video sections on dashboard with purchased products
- show product details in modal on dashboard
- move "Continuar Assistindo" section to Videos page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6866df735e388332a1ee9a145a11c292