### PR TITLE
Add user progress tracking feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Settings from './pages/Settings';
 import Payment from './pages/Payment';
 import AdminDashboard from './pages/AdminDashboard';
 import Emagrecimento from './pages/Emagrecimento';
+import Progress from './pages/Progress';
 
 function App() {
   return (
@@ -42,6 +43,7 @@ function App() {
             <Route path="store" element={<Store />} />
             <Route path="favorites" element={<Favorites />} />
             <Route path="profile" element={<Profile />} />
+            <Route path="progress" element={<Progress />} />
             <Route path="payment" element={<Payment />} />
             <Route path="settings" element={<Settings />} />
             <Route path="emagrecimento" element={<Emagrecimento />} />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -1,4 +1,3 @@
-// Estrutura base utilizada em todas as páginas protegidas
 import React, { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
@@ -10,26 +9,16 @@ const Layout: React.FC = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    {/* Container principal do layout */}
     <div className="min-h-screen bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-white">
       <div className="flex">
-        {/* Sidebar */}
-        <Sidebar 
-          isOpen={sidebarOpen} 
-          onClose={() => setSidebarOpen(false)} 
-        />
-        
-        {/* Main content */}
+        <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
         <div className="flex-1 lg:ml-0">
           <Header onMenuClick={() => setSidebarOpen(true)} />
-          
           <main className="p-6">
             <Outlet />
           </main>
         </div>
       </div>
-      
-      {/* Cart sidebar */}
       <Cart />
       <ProfileModal />
     </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -73,11 +73,11 @@ const Dashboard: React.FC = () => {
         })}
       </div>
 
-      {/* Weight Loss Tool */}
+      {/* AugeFit Planner */}
       <section className="bg-slate-800 rounded-lg p-6 flex flex-col sm:flex-row items-center justify-between">
         <div className="mb-4 sm:mb-0">
-          <h2 className="text-xl font-bold text-white">Ferramenta de Emagrecimento</h2>
-          <p className="text-sm text-slate-400">Calcule seu plano personalizado</p>
+          <h2 className="text-xl font-bold text-white">AugeFit Planner</h2>
+          <p className="text-sm text-slate-400">Monte seu plano de emagrecimento</p>
         </div>
         <Link
           to="/emagrecimento"

--- a/src/pages/Emagrecimento.tsx
+++ b/src/pages/Emagrecimento.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { mockVideos, mockProducts } from '../data/mockData';
 import type { Product } from '../stores/cartStore';
 import type { Video } from '../stores/favoritesStore';
+import { useProgressStore } from '../stores/progressStore';
 
 interface FormData {
   height: number;
@@ -34,6 +35,7 @@ const diets = [
 const Emagrecimento: React.FC = () => {
   const [data, setData] = useState<FormData>(initialData);
   const [submitted, setSubmitted] = useState(false);
+  const { setWeightLoss } = useProgressStore();
 
   const imc = useMemo(() => {
     if (!data.height || !data.currentWeight) return 0;
@@ -48,6 +50,12 @@ const Emagrecimento: React.FC = () => {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     setSubmitted(true);
+    setWeightLoss({
+      ...data,
+      imc,
+      idealWeight,
+      dailyDeficit,
+    });
   };
 
   const idealWeight = useMemo(() => {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { User, Camera, Edit3, Save, X } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
+import { useProgressStore } from '../stores/progressStore';
 
 const Profile: React.FC = () => {
   const { user, updateUser } = useAuth();
@@ -9,9 +10,11 @@ const Profile: React.FC = () => {
     name: user?.name || '',
     email: user?.email || '',
   });
+  const { metrics, setMetrics } = useProgressStore();
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const [bodyForm, setBodyForm] = useState(metrics);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
@@ -23,6 +26,7 @@ const Profile: React.FC = () => {
 
   const handleSave = async () => {
     await updateUser({ name: formData.name, email: formData.email, file });
+    setMetrics(bodyForm);
     setIsEditing(false);
     setFile(null);
     setPreview(null);
@@ -33,6 +37,7 @@ const Profile: React.FC = () => {
       name: user?.name || '',
       email: user?.email || '',
     });
+    setBodyForm(metrics);
     setFile(null);
     setPreview(null);
     setIsEditing(false);
@@ -45,7 +50,10 @@ const Profile: React.FC = () => {
         <h1 className="text-3xl font-bold text-white">Meu Perfil</h1>
         {!isEditing ? (
           <button
-            onClick={() => setIsEditing(true)}
+            onClick={() => {
+              setBodyForm(metrics);
+              setIsEditing(true);
+            }}
             className="flex items-center space-x-2 bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
           >
             <Edit3 className="w-4 h-4" />
@@ -109,6 +117,12 @@ const Profile: React.FC = () => {
                 <div className="inline-flex items-center px-3 py-1 bg-yellow-500 text-black rounded-full text-sm font-medium">
                   Membro Premium
                 </div>
+                <div className="grid grid-cols-2 gap-2 text-sm text-slate-300 mt-4">
+                  <span>Peso: {metrics.totalWeight}kg</span>
+                  <span>IMC: {metrics.bmi}</span>
+                  <span>Água Total: {metrics.totalBodyWater}L</span>
+                  <span>Massa Magra: {metrics.leanMass}kg</span>
+                </div>
               </div>
             ) : (
               <div className="space-y-4 max-w-md">
@@ -129,6 +143,152 @@ const Profile: React.FC = () => {
                     onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                     className="w-full bg-slate-700 border border-slate-600 rounded-lg px-3 py-2 text-white focus:outline-none focus:ring-2 focus:ring-teal-500"
                   />
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Peso Corporal (kg)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.totalWeight}
+                      onChange={(e) => setBodyForm({ ...bodyForm, totalWeight: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">IMC</span>
+                    <input
+                      type="number"
+                      value={bodyForm.bmi}
+                      onChange={(e) => setBodyForm({ ...bodyForm, bmi: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Água Corporal Total (L)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.totalBodyWater}
+                      onChange={(e) => setBodyForm({ ...bodyForm, totalBodyWater: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Água Intracelular (L)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.intracellularWater}
+                      onChange={(e) => setBodyForm({ ...bodyForm, intracellularWater: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Água Extracelular (L)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.extracellularWater}
+                      onChange={(e) => setBodyForm({ ...bodyForm, extracellularWater: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Massa Magra (kg)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.leanMass}
+                      onChange={(e) => setBodyForm({ ...bodyForm, leanMass: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Massa Muscular Esquelética (kg)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.skeletalMuscleMass}
+                      onChange={(e) => setBodyForm({ ...bodyForm, skeletalMuscleMass: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Massa de Gordura (kg)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.bodyFatMass}
+                      onChange={(e) => setBodyForm({ ...bodyForm, bodyFatMass: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">% Gordura Corporal</span>
+                    <input
+                      type="number"
+                      value={bodyForm.bodyFatPercent}
+                      onChange={(e) => setBodyForm({ ...bodyForm, bodyFatPercent: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Gordura Braços (%)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.fatArms}
+                      onChange={(e) => setBodyForm({ ...bodyForm, fatArms: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Gordura Tronco (%)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.fatTrunk}
+                      onChange={(e) => setBodyForm({ ...bodyForm, fatTrunk: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Gordura Pernas (%)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.fatLegs}
+                      onChange={(e) => setBodyForm({ ...bodyForm, fatLegs: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Massa Óssea (kg)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.boneMass}
+                      onChange={(e) => setBodyForm({ ...bodyForm, boneMass: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">TMB (kcal)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.bmr}
+                      onChange={(e) => setBodyForm({ ...bodyForm, bmr: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Relação ECW/ICW</span>
+                    <input
+                      type="number"
+                      value={bodyForm.ecwIcwRatio}
+                      onChange={(e) => setBodyForm({ ...bodyForm, ecwIcwRatio: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
+                  <label className="flex flex-col">
+                    <span className="text-sm mb-1">Equilíbrio Muscular (%)</span>
+                    <input
+                      type="number"
+                      value={bodyForm.muscleSymmetry}
+                      onChange={(e) => setBodyForm({ ...bodyForm, muscleSymmetry: Number(e.target.value) })}
+                      className="input"
+                    />
+                  </label>
                 </div>
               </div>
             )}

--- a/src/pages/Progress.tsx
+++ b/src/pages/Progress.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { TrendingUp } from 'lucide-react';
+import { useProgressStore } from '../stores/progressStore';
+
+const Progress: React.FC = () => {
+  const { weightLoss, metrics } = useProgressStore();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center space-x-3">
+        <TrendingUp className="w-8 h-8 text-teal-500" />
+        <h1 className="text-3xl font-bold text-white">Meu Progresso</h1>
+      </div>
+
+      {weightLoss && (
+        <section className="bg-slate-800 rounded-lg p-6">
+          <h2 className="text-xl font-semibold text-white mb-2">AugeFit Planner</h2>
+          <p className="text-slate-400 mb-1">
+            Objetivo: {weightLoss.targetWeight}kg em {weightLoss.goalTime} semanas
+          </p>
+          <p className="text-slate-400 mb-1">IMC atual: {weightLoss.imc.toFixed(1)}</p>
+          <p className="text-slate-400 mb-1">Peso ideal: {weightLoss.idealWeight.toFixed(1)}kg</p>
+          <p className="text-slate-400">Déficit diário sugerido: {weightLoss.dailyDeficit} kcal</p>
+        </section>
+      )}
+
+      <section className="bg-slate-800 rounded-lg p-6">
+        <h2 className="text-xl font-semibold text-white mb-4">Composição Corporal</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-slate-300">
+          <div>
+            <span className="font-medium text-white">Peso Corporal:</span> {metrics.totalWeight}kg
+          </div>
+          <div>
+            <span className="font-medium text-white">IMC:</span> {metrics.bmi}
+          </div>
+          <div>
+            <span className="font-medium text-white">Água Corporal Total:</span> {metrics.totalBodyWater}L
+          </div>
+          <div>
+            <span className="font-medium text-white">Água Intracelular:</span> {metrics.intracellularWater}L
+          </div>
+          <div>
+            <span className="font-medium text-white">Água Extracelular:</span> {metrics.extracellularWater}L
+          </div>
+          <div>
+            <span className="font-medium text-white">Massa Magra:</span> {metrics.leanMass}kg
+          </div>
+          <div>
+            <span className="font-medium text-white">Massa Muscular Esquelética:</span> {metrics.skeletalMuscleMass}kg
+          </div>
+          <div>
+            <span className="font-medium text-white">Massa de Gordura:</span> {metrics.bodyFatMass}kg
+          </div>
+          <div>
+            <span className="font-medium text-white">% Gordura Corporal:</span> {metrics.bodyFatPercent}%
+          </div>
+          <div>
+            <span className="font-medium text-white">Gordura Braços:</span> {metrics.fatArms}%
+          </div>
+          <div>
+            <span className="font-medium text-white">Gordura Tronco:</span> {metrics.fatTrunk}%
+          </div>
+          <div>
+            <span className="font-medium text-white">Gordura Pernas:</span> {metrics.fatLegs}%
+          </div>
+          <div>
+            <span className="font-medium text-white">Massa Óssea:</span> {metrics.boneMass}kg
+          </div>
+          <div>
+            <span className="font-medium text-white">TMB:</span> {metrics.bmr} kcal
+          </div>
+          <div>
+            <span className="font-medium text-white">Relação ECW/ICW:</span> {metrics.ecwIcwRatio}
+          </div>
+          <div>
+            <span className="font-medium text-white">Equilíbrio Muscular:</span> {metrics.muscleSymmetry}%
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default Progress;

--- a/src/stores/progressStore.ts
+++ b/src/stores/progressStore.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand';
+
+export interface WeightLossData {
+  height: number;
+  currentWeight: number;
+  targetWeight: number;
+  goalTime: number;
+  frequency: number;
+  impedance?: string;
+  diet: string;
+  medicalNotes?: string;
+  imc: number;
+  idealWeight: number;
+  dailyDeficit: number;
+}
+
+export interface BodyMetrics {
+  totalWeight: number;
+  bmi: number;
+  totalBodyWater: number;
+  intracellularWater: number;
+  extracellularWater: number;
+  leanMass: number;
+  skeletalMuscleMass: number;
+  bodyFatMass: number;
+  bodyFatPercent: number;
+  fatArms: number;
+  fatTrunk: number;
+  fatLegs: number;
+  boneMass: number;
+  bmr: number;
+  ecwIcwRatio: number;
+  muscleSymmetry: number;
+}
+
+interface ProgressStore {
+  weightLoss?: WeightLossData;
+  metrics: BodyMetrics;
+  setWeightLoss: (data: WeightLossData) => void;
+  setMetrics: (data: Partial<BodyMetrics>) => void;
+}
+
+const defaultMetrics: BodyMetrics = {
+  totalWeight: 0,
+  bmi: 0,
+  totalBodyWater: 0,
+  intracellularWater: 0,
+  extracellularWater: 0,
+  leanMass: 0,
+  skeletalMuscleMass: 0,
+  bodyFatMass: 0,
+  bodyFatPercent: 0,
+  fatArms: 0,
+  fatTrunk: 0,
+  fatLegs: 0,
+  boneMass: 0,
+  bmr: 0,
+  ecwIcwRatio: 0,
+  muscleSymmetry: 0,
+};
+
+export const useProgressStore = create<ProgressStore>((set) => ({
+  weightLoss: undefined,
+  metrics: defaultMetrics,
+  setWeightLoss: (data) => set({ weightLoss: data }),
+  setMetrics: (data) => set((state) => ({ metrics: { ...state.metrics, ...data } })),
+}));


### PR DESCRIPTION
## Summary
- add progress store for body metrics and weight loss data
- save plan results on Emagrecimento page
- show AugeFit Planner card on Dashboard
- collect body metrics in Profile and display summary
- implement Progress page to display stored data
- fix Layout component
- register progress route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6867026b03888332b66abb63fff7cc1e