### PR TITLE
Convert questionnaire to TSX

### DIFF
--- a/src/components/Questionnaire.tsx
+++ b/src/components/Questionnaire.tsx
@@ -133,7 +133,11 @@ const steps = [
   },
 ];
 
-export default function Questionnaire({ onComplete }) {
+export interface QuestionnaireProps {
+  onComplete?: (data: any) => void;
+}
+
+export default function Questionnaire({ onComplete }: QuestionnaireProps) {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({});
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -1,4 +1,9 @@
 import React from 'react';
+
+export interface ReportProps {
+  data: any;
+  onBack: () => void;
+}
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
@@ -51,7 +56,7 @@ const macroData = [
   { name: 'Gorduras', value: 30, color: '#f59e0b' },
 ];
 
-export default function Report({ data, onBack }) {
+export default function Report({ data, onBack }: ReportProps) {
   if (!data) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 flex items-center justify-center p-4">

--- a/src/components/questionnaire/StepFive.tsx
+++ b/src/components/questionnaire/StepFive.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -22,7 +23,7 @@ const habitosAlimentares = [
   { id: 'fast_food', label: 'Fast food ocasionalmente' },
 ];
 
-export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultValues }) {
+export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepFour.tsx
+++ b/src/components/questionnaire/StepFour.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Checkbox } from '../ui/checkbox';
@@ -22,7 +23,7 @@ const equipamentos = [
   { id: 'peso_corporal', label: 'Apenas peso corporal', icon: '💪' },
 ];
 
-export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultValues }) {
+export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepOne.tsx
+++ b/src/components/questionnaire/StepOne.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -6,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '.
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
 import { ArrowRight } from 'lucide-react';
 
-export default function StepOne({ form, onNext, defaultValues }) {
+export default function StepOne({ form, onNext, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepSeven.tsx
+++ b/src/components/questionnaire/StepSeven.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Textarea } from '../ui/textarea';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
 import { ArrowLeft, CheckCircle, BarChart3 } from 'lucide-react';
 
-export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastStep, defaultValues }) {
+export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastStep, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepSix.tsx
+++ b/src/components/questionnaire/StepSix.tsx
@@ -1,11 +1,12 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '../ui/form';
 import { ArrowLeft, ArrowRight, Target, Heart, Users } from 'lucide-react';
 
-export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultValues }) {
+export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepThree.tsx
+++ b/src/components/questionnaire/StepThree.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Checkbox } from '../ui/checkbox';
@@ -21,7 +22,7 @@ const habitosSociais = [
   { id: 'nenhum', label: 'Nenhum dos anteriores' },
 ];
 
-export default function StepThree({ form, onNext, onPrevious, canGoBack, defaultValues }) {
+export default function StepThree({ form, onNext, onPrevious, canGoBack, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/StepTwo.tsx
+++ b/src/components/questionnaire/StepTwo.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { StepProps } from './types';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -16,7 +17,7 @@ const condicoesMedicas = [
   { id: 'nenhuma', label: 'Nenhuma' },
 ];
 
-export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultValues }) {
+export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultValues }: StepProps) {
   useEffect(() => {
     if (defaultValues) {
       Object.keys(defaultValues).forEach(key => {

--- a/src/components/questionnaire/types.ts
+++ b/src/components/questionnaire/types.ts
@@ -1,0 +1,10 @@
+import { UseFormReturn } from 'react-hook-form';
+
+export interface StepProps {
+  form: UseFormReturn<any>;
+  onNext: (data: any) => void;
+  onPrevious?: () => void;
+  canGoBack?: boolean;
+  isLastStep?: boolean;
+  defaultValues?: Record<string, any>;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,6 +10,7 @@
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
+    "allowJs": true,
     "moduleDetection": "force",
     "noEmit": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- allow importing JS/JSX files in the TypeScript config
- convert questionnaire flow components to `.tsx`
- add reusable `StepProps` type
- type the `Report` component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6867ba8823d08332a0170be5d15fc19f