### PR TITLE
Add public home page with login redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import Layout from './components/Layout/Layout';
 import Auth from './pages/Auth';
+import Home from './pages/Home';
 import Dashboard from './pages/Dashboard';
 import Videos from './pages/Videos';
 import Store from './pages/Store';
@@ -23,6 +24,7 @@ function App() {
     <AuthProvider>
       <Router>
         <Routes>
+          <Route path="/" element={<Home />} />
           <Route path="/auth" element={<Auth />} />
           <Route
             path="/*"

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Navigate, useNavigate } from 'react-router-dom';
+import { PLANS } from '../data/plans';
+import { Button } from '../components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
+import { CheckCircle } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+
+const Home: React.FC = () => {
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  if (user) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const handleGetPlan = () => {
+    navigate('/auth');
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-white py-12">
+      <div className="max-w-4xl mx-auto space-y-8 px-4">
+        <h1 className="text-4xl font-bold text-center">Escolha seu plano</h1>
+        <div className="grid md:grid-cols-3 gap-6">
+          {PLANS.map((p) => (
+            <Card key={p.id} className="bg-slate-900">
+              <CardHeader className="text-center">
+                <CardTitle className="text-white">{p.name}</CardTitle>
+                <CardDescription className="text-primary">{p.price}</CardDescription>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                <ul className="text-sm space-y-1 list-disc list-inside text-slate-300">
+                  {p.features.map((f) => (
+                    <li key={f} className="flex items-center gap-2">
+                      <CheckCircle className="w-4 h-4 text-emerald-500" /> {f}
+                    </li>
+                  ))}
+                </ul>
+                <Button onClick={handleGetPlan} className="w-full mt-4">
+                  Obter Plano
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Home;


### PR DESCRIPTION
## Summary
- create `Home` page listing available plans
- route `/` to the new Home page
- redirect to login when a plan is chosen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bc0ab6f788332ae2818ecbcec5c86