### PR TITLE
Fix home login navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,6 +26,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/auth" element={<Auth />} />
+          <Route path="/login" element={<Navigate to="/auth" replace />} />
           <Route
             path="/*"
             element={

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
 import { PLANS } from '../data/plans';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../components/ui/card';
@@ -15,12 +15,20 @@ const Home: React.FC = () => {
   }
 
   const handleGetPlan = () => {
-    navigate('/auth');
+    navigate('/login');
   };
 
   return (
     <div className="min-h-screen bg-slate-950 text-white py-12">
       <div className="max-w-4xl mx-auto space-y-8 px-4">
+        <div className="flex justify-end">
+          <Link
+            to="/login"
+            className="text-primary hover:underline font-medium"
+          >
+            Entrar
+          </Link>
+        </div>
         <h1 className="text-4xl font-bold text-center">Escolha seu plano</h1>
         <div className="grid md:grid-cols-3 gap-6">
           {PLANS.map((p) => (


### PR DESCRIPTION
## Summary
- add alias `/login` route mapping to auth screen
- include login link on home page
- route plan selection to login screen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bc3c3d7208332904d0ae4d5f68445