### PR TITLE
Fix Home handler typing and standardize button props

### DIFF
--- a/src/components/Report.tsx
+++ b/src/components/Report.tsx
@@ -63,7 +63,7 @@ export default function Report({ data, onBack }: ReportProps) {
         <Card className="w-full max-w-md">
           <CardContent className="p-8 text-center">
             <p className="text-gray-600">Nenhum dado de relatório disponível.</p>
-            <Button onClick={onBack} className="mt-4">
+            <Button variant="default" size="sm" onClick={onBack} className="mt-4">
               Voltar ao Questionário
             </Button>
           </CardContent>
@@ -162,11 +162,11 @@ export default function Report({ data, onBack }: ReportProps) {
             </p>
           </div>
           <div className="flex gap-3">
-            <Button variant="outline" className="flex items-center gap-2">
+            <Button variant="outline" size="sm" className="flex items-center gap-2">
               <Download className="w-4 h-4" />
               Baixar PDF
             </Button>
-            <Button variant="outline" className="flex items-center gap-2">
+            <Button variant="outline" size="sm" className="flex items-center gap-2">
               <Share2 className="w-4 h-4" />
               Compartilhar
             </Button>
@@ -620,7 +620,7 @@ export default function Report({ data, onBack }: ReportProps) {
         {/* Botão Voltar */}
         {onBack && (
           <div className="text-center mt-8">
-            <Button variant="outline" onClick={onBack}>
+            <Button variant="outline" size="sm" onClick={onBack}>
               Voltar ao Questionário
             </Button>
           </div>

--- a/src/components/questionnaire/StepFive.tsx
+++ b/src/components/questionnaire/StepFive.tsx
@@ -298,9 +298,10 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -308,8 +309,10 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
+            size="sm"
             className="flex items-center gap-2 h-12 px-8 ml-auto"
           >
             Próximo

--- a/src/components/questionnaire/StepFour.tsx
+++ b/src/components/questionnaire/StepFour.tsx
@@ -300,9 +300,10 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -310,8 +311,10 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
+            size="sm"
             className="flex items-center gap-2 h-12 px-8 ml-auto"
           >
             Próximo

--- a/src/components/questionnaire/StepOne.tsx
+++ b/src/components/questionnaire/StepOne.tsx
@@ -203,6 +203,7 @@ export default function StepOne({ form, onNext, defaultValues }: StepProps) {
         <div className="flex justify-end pt-4">
           <Button
             type="submit"
+            variant="default"
             className="flex items-center gap-2 h-12 px-8 rounded-xl"
             size="lg"
           >

--- a/src/components/questionnaire/StepSeven.tsx
+++ b/src/components/questionnaire/StepSeven.tsx
@@ -212,9 +212,10 @@ export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastS
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -222,8 +223,9 @@ export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastS
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
             className="flex items-center gap-2 h-12 px-8 ml-auto bg-green-600 hover:bg-green-700"
             size="lg"
           >

--- a/src/components/questionnaire/StepSix.tsx
+++ b/src/components/questionnaire/StepSix.tsx
@@ -284,9 +284,10 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -294,8 +295,10 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
+            size="sm"
             className="flex items-center gap-2 h-12 px-8 ml-auto"
           >
             Próximo

--- a/src/components/questionnaire/StepThree.tsx
+++ b/src/components/questionnaire/StepThree.tsx
@@ -280,9 +280,10 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -290,8 +291,10 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
+            size="sm"
             className="flex items-center gap-2 h-12 px-8 ml-auto"
           >
             Próximo

--- a/src/components/questionnaire/StepTwo.tsx
+++ b/src/components/questionnaire/StepTwo.tsx
@@ -212,9 +212,10 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
         {/* Botões de navegação */}
         <div className="flex justify-between pt-6">
           {canGoBack && (
-            <Button 
-              type="button" 
-              variant="outline" 
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
               onClick={onPrevious}
               className="flex items-center gap-2 h-12 px-8"
             >
@@ -222,8 +223,10 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
               Anterior
             </Button>
           )}
-          <Button 
-            type="submit" 
+          <Button
+            type="submit"
+            variant="default"
+            size="sm"
             className="flex items-center gap-2 h-12 px-8 ml-auto"
           >
             Próximo

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -14,7 +14,7 @@ const Home: React.FC = () => {
     return <Navigate to="/dashboard" replace />;
   }
 
-  const handleGetPlan = () => {
+  const handleSelectPlan = (planName: string) => {
     navigate('/login');
   };
 
@@ -45,7 +45,12 @@ const Home: React.FC = () => {
                     </li>
                   ))}
                 </ul>
-                <Button onClick={handleGetPlan} className="w-full mt-4">
+                <Button
+                  variant="default"
+                  size="sm"
+                  onClick={() => handleSelectPlan(p.id)}
+                  className="w-full mt-4"
+                >
                   Obter Plano
                 </Button>
               </CardContent>


### PR DESCRIPTION
## Summary
- add `handleSelectPlan` with typed parameter
- update `Home` buttons to include `variant` and `size`
- ensure all `Button` components across questionnaire and report pages include mandatory props

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bcb2077e483329e223ae8f8ea2339