### PR TITLE
Refine home page and add about section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import AdminDashboard from './pages/AdminDashboard';
 import Emagrecimento from './pages/Emagrecimento';
 import Progress from './pages/Progress';
 import AppsPage from './pages/Apps';
+import About from './pages/About';
 
 function App() {
   return (
@@ -25,6 +26,7 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
           <Route path="/auth" element={<Auth />} />
           <Route path="/login" element={<Navigate to="/auth" replace />} />
           <Route

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const About: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white py-16 px-4">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold text-center">Sobre o Seu Auge</h1>
+        <p>
+          O <strong>Seu Auge</strong> nasceu com a missão de facilitar o acesso a
+          conteúdo de qualidade sobre saúde, nutrição e bem-estar. Nossa equipe
+          reúne profissionais apaixonados por transformar vidas por meio de
+          orientações confiáveis e ferramentas que impulsionam resultados.
+        </p>
+        <p>
+          Aqui você encontrará vídeos, planos personalizados e uma comunidade
+          pronta para apoiar cada etapa da sua jornada. Acreditamos que o
+          equilíbrio entre mente e corpo é essencial para atingir o máximo
+          potencial e queremos estar ao seu lado nesse processo.
+        </p>
+        <p>
+          Junte-se a nós e descubra como pequenos hábitos podem gerar grandes
+          mudanças. Estamos comprometidos em oferecer uma experiência segura e
+          motivadora para que você alcance seus objetivos com tranquilidade.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default About;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -15,21 +15,19 @@ const Home: React.FC = () => {
   }
 
   const handleSelectPlan = (planName: string) => {
-    navigate('/login');
+    navigate('/auth');
   };
 
   return (
-    <div className="min-h-screen bg-slate-950 text-white py-12">
-      <div className="max-w-4xl mx-auto space-y-8 px-4">
+    <div className="relative min-h-screen bg-slate-950 text-white py-12">
+      <div className="absolute inset-0 bg-gradient-to-br from-primary via-emerald-600 to-cyan-600 opacity-20" />
+      <div className="relative max-w-4xl mx-auto space-y-8 px-4">
         <div className="flex justify-end">
-          <Link
-            to="/login"
-            className="text-primary hover:underline font-medium"
-          >
+          <Link to="/auth" className="text-primary hover:underline font-medium">
             Entrar
           </Link>
         </div>
-        <h1 className="text-4xl font-bold text-center">Escolha seu plano</h1>
+        <h1 className="text-4xl font-bold text-center">Comece grátis</h1>
         <div className="grid md:grid-cols-3 gap-6">
           {PLANS.map((p) => (
             <Card key={p.id} className="bg-slate-900">
@@ -51,7 +49,7 @@ const Home: React.FC = () => {
                   onClick={() => handleSelectPlan(p.id)}
                   className="w-full mt-4"
                 >
-                  Obter Plano
+                  Comece Grátis
                 </Button>
               </CardContent>
             </Card>

--- a/tela principal.jsx
+++ b/tela principal.jsx
@@ -100,14 +100,6 @@ function App() {
               Iniciar Transformação
               <ArrowRight className="w-5 h-5 ml-2" />
             </Button>
-            <Button 
-              size="lg" 
-              variant="outline"
-              className="h-14 px-8 text-lg border-orange-200 text-orange-700 hover:bg-orange-50"
-            >
-              <Trophy className="w-5 h-5 mr-2" />
-              Ver Resultados
-            </Button>
           </div>
 
           {/* Stats */}


### PR DESCRIPTION
## Summary
- remove obsolete "Ver Resultados" button
- create `About` page with introductory text
- adjust home to use the login palette and update CTA text
- update routes to include the new About page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686bd0ebaf9c833294bef1ce0c6a2332