### PR TITLE
Improve login routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,8 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/about" element={<About />} />
           <Route path="/auth" element={<Auth />} />
-          <Route path="/login" element={<Navigate to="/auth" replace />} />
+          <Route path="/login" element={<Navigate to="/auth?mode=login" replace />} />
+          <Route path="/register" element={<Navigate to="/auth?mode=register" replace />} />
           <Route
             path="/*"
             element={

--- a/src/components/Auth/LoginForm.tsx
+++ b/src/components/Auth/LoginForm.tsx
@@ -11,6 +11,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onToggleMode }) => {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const { login } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -19,8 +20,10 @@ const LoginForm: React.FC<LoginFormProps> = ({ onToggleMode }) => {
     
     try {
       await login(email, password);
+      setError(null);
     } catch (error) {
       console.error('Erro no login:', error);
+      setError('Falha ao entrar. Verifique suas credenciais.');
     } finally {
       setLoading(false);
     }
@@ -43,7 +46,10 @@ const LoginForm: React.FC<LoginFormProps> = ({ onToggleMode }) => {
             <input
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setError(null);
+              }}
               className="w-full pl-12 pr-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               placeholder="Digite seu email"
               required
@@ -60,7 +66,10 @@ const LoginForm: React.FC<LoginFormProps> = ({ onToggleMode }) => {
             <input
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setError(null);
+              }}
               className="w-full pl-12 pr-12 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               placeholder="Digite sua senha"
               required
@@ -75,6 +84,7 @@ const LoginForm: React.FC<LoginFormProps> = ({ onToggleMode }) => {
           </div>
         </div>
 
+        {error && <p className="text-red-500 text-sm">{error}</p>}
         <button
           type="submit"
           disabled={loading}

--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -12,6 +12,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const { register } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -20,8 +21,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
     
     try {
       await register(email, password, name);
+      setError(null);
     } catch (error) {
       console.error('Erro no cadastro:', error);
+      setError('Falha ao criar conta. Verifique os dados informados.');
     } finally {
       setLoading(false);
     }
@@ -44,7 +47,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
             <input
               type="text"
               value={name}
-              onChange={(e) => setName(e.target.value)}
+              onChange={(e) => {
+                setName(e.target.value);
+                setError(null);
+              }}
               className="w-full pl-12 pr-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               placeholder="Digite seu nome completo"
               required
@@ -61,7 +67,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
             <input
               type="email"
               value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              onChange={(e) => {
+                setEmail(e.target.value);
+                setError(null);
+              }}
               className="w-full pl-12 pr-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               placeholder="Digite seu email"
               required
@@ -78,7 +87,10 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
             <input
               type={showPassword ? 'text' : 'password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) => {
+                setPassword(e.target.value);
+                setError(null);
+              }}
               className="w-full pl-12 pr-12 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
               placeholder="Crie uma senha"
               required
@@ -93,6 +105,7 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
           </div>
         </div>
 
+        {error && <p className="text-red-500 text-sm">{error}</p>}
         <button
           type="submit"
           disabled={loading}

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -19,7 +19,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!user) {
-    return <Navigate to="/auth" replace state={{ from: location }} />;
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
   return <>{children}</>;

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { TrendingUp } from 'lucide-react';
 import LoginForm from '../components/Auth/LoginForm';
 import RegisterForm from '../components/Auth/RegisterForm';
 import { useAuth } from '../contexts/AuthContext';
 
 const Auth: React.FC = () => {
-  const [isLogin, setIsLogin] = useState(true);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialMode = searchParams.get('mode') === 'register' ? false : true;
+  const [isLogin, setIsLogin] = useState(initialMode);
   const { user, loading } = useAuth();
 
   if (loading) {
@@ -76,9 +78,19 @@ const Auth: React.FC = () => {
           </div>
 
           {isLogin ? (
-            <LoginForm onToggleMode={() => setIsLogin(false)} />
+            <LoginForm
+              onToggleMode={() => {
+                setSearchParams({ mode: 'register' });
+                setIsLogin(false);
+              }}
+            />
           ) : (
-            <RegisterForm onToggleMode={() => setIsLogin(true)} />
+            <RegisterForm
+              onToggleMode={() => {
+                setSearchParams({ mode: 'login' });
+                setIsLogin(true);
+              }}
+            />
           )}
         </div>
       </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -15,7 +15,7 @@ const Home: React.FC = () => {
   }
 
   const handleSelectPlan = (planName: string) => {
-    navigate('/auth');
+    navigate('/login');
   };
 
   return (
@@ -23,7 +23,7 @@ const Home: React.FC = () => {
       <div className="absolute inset-0 bg-gradient-to-br from-primary via-emerald-600 to-cyan-600 opacity-20" />
       <div className="relative max-w-4xl mx-auto space-y-8 px-4">
         <div className="flex justify-end">
-          <Link to="/auth" className="text-primary hover:underline font-medium">
+          <Link to="/login" className="text-primary hover:underline font-medium">
             Entrar
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- update login and register forms with basic error feedback
- implement query param logic in Auth page
- update routing to use /login and /register
- adjust home page buttons to point to new login route
- redirect unauthenticated users to /login

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd6482a7c83329a3856628854d9ea