### PR TITLE
Improve questionnaire dark mode

### DIFF
--- a/src/components/Questionnaire.tsx
+++ b/src/components/Questionnaire.tsx
@@ -254,12 +254,12 @@ export default function Questionnaire({ onComplete }: QuestionnaireProps) {
 
   if (isSubmitting) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 flex items-center justify-center p-4">
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-slate-900 dark:to-slate-800 flex items-center justify-center p-4">
         <Card className="w-full max-w-md">
           <CardContent className="p-8 text-center">
             <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
             <h3 className="text-lg font-semibold mb-2">Processando seus dados...</h3>
-            <p className="text-gray-600">Gerando seu plano personalizado</p>
+            <p className="text-gray-600 dark:text-gray-300">Gerando seu plano personalizado</p>
           </CardContent>
         </Card>
       </div>
@@ -267,14 +267,14 @@ export default function Questionnaire({ onComplete }: QuestionnaireProps) {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 p-4">
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50 dark:from-slate-900 dark:to-slate-800 p-4">
       <div className="max-w-4xl mx-auto">
         {/* Header */}
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
             Questionário Personalizado
           </h1>
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-400">
             Responda algumas perguntas para criarmos seu plano ideal
           </p>
         </div>
@@ -282,7 +282,7 @@ export default function Questionnaire({ onComplete }: QuestionnaireProps) {
         {/* Progress */}
         <div className="mb-8">
           <div className="flex justify-between items-center mb-4">
-            <span className="text-sm font-medium text-gray-700">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
               Etapa {currentStep} de {steps.length}
             </span>
             <Badge variant="secondary" className="flex items-center gap-1">
@@ -306,28 +306,28 @@ export default function Questionnaire({ onComplete }: QuestionnaireProps) {
                   key={step.id}
                   className={`flex flex-col items-center p-3 rounded-lg min-w-[120px] ${
                     isActive
-                      ? 'bg-blue-100 border-2 border-blue-500'
+                      ? 'bg-primary/20 dark:bg-primary/30 border-2 border-primary'
                       : isCompleted
-                      ? 'bg-green-100 border-2 border-green-500'
-                      : 'bg-gray-100 border-2 border-gray-200'
+                      ? 'bg-green-100 dark:bg-green-900/30 border-2 border-green-500'
+                      : 'bg-gray-100 dark:bg-slate-700 border-2 border-gray-200 dark:border-slate-600'
                   }`}
                 >
                   <Icon
                     className={`w-6 h-6 mb-2 ${
                       isActive
-                        ? 'text-blue-600'
+                        ? 'text-primary'
                         : isCompleted
                         ? 'text-green-600'
-                        : 'text-gray-400'
+                        : 'text-gray-400 dark:text-gray-500'
                     }`}
                   />
                   <span
                     className={`text-xs font-medium text-center ${
                       isActive
-                        ? 'text-blue-900'
+                        ? 'text-primary' 
                         : isCompleted
                         ? 'text-green-900'
-                        : 'text-gray-600'
+                        : 'text-gray-600 dark:text-gray-300'
                     }`}
                   >
                     {step.title}
@@ -342,7 +342,7 @@ export default function Questionnaire({ onComplete }: QuestionnaireProps) {
         <Card className="mb-8">
           <CardHeader>
             <div className="flex items-center gap-3">
-              <currentStepData.icon className="w-6 h-6 text-blue-600" />
+              <currentStepData.icon className="w-6 h-6 text-primary" />
               <div>
                 <CardTitle>{currentStepData.title}</CardTitle>
                 <CardDescription>{currentStepData.description}</CardDescription>

--- a/src/components/questionnaire/StepFive.tsx
+++ b/src/components/questionnaire/StepFive.tsx
@@ -55,25 +55,25 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                   defaultValue={field.value}
                   className="grid grid-cols-1 md:grid-cols-2 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="onivoro" id="pref-onivoro" />
                     <Label htmlFor="pref-onivoro" className="cursor-pointer">
                       🍖 Onívoro (como de tudo)
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="vegetariano" id="pref-vegetariano" />
                     <Label htmlFor="pref-vegetariano" className="cursor-pointer">
                       🥬 Vegetariano
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="vegano" id="pref-vegano" />
                     <Label htmlFor="pref-vegano" className="cursor-pointer">
                       🌱 Vegano
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="pescetariano" id="pref-pescetariano" />
                     <Label htmlFor="pref-pescetariano" className="cursor-pointer">
                       🐟 Pescetariano
@@ -106,7 +106,7 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                       return (
                         <FormItem
                           key={restricao.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -182,7 +182,7 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                       return (
                         <FormItem
                           key={habito.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -224,7 +224,7 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="baixo" id="orc-baixo" />
                     <div className="flex-1">
                       <Label htmlFor="orc-baixo" className="cursor-pointer font-medium">
@@ -233,7 +233,7 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                       <p className="text-sm text-gray-600">Foco em alimentos básicos e econômicos</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="medio" id="orc-medio" />
                     <div className="flex-1">
                       <Label htmlFor="orc-medio" className="cursor-pointer font-medium">
@@ -242,7 +242,7 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
                       <p className="text-sm text-gray-600">Variedade moderada de alimentos</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="alto" id="orc-alto" />
                     <div className="flex-1">
                       <Label htmlFor="orc-alto" className="cursor-pointer font-medium">
@@ -287,10 +287,10 @@ export default function StepFive({ form, onNext, onPrevious, canGoBack, defaultV
         />
 
         {/* Dica nutricional */}
-        <div className="bg-green-50 p-4 rounded-lg border border-green-200">
-          <h4 className="font-medium text-green-900 mb-2">🥗 Dica Nutricional</h4>
-          <p className="text-sm text-green-700">
-            Uma alimentação equilibrada é 70% do sucesso na perda de peso. Nosso plano será 
+        <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg border border-green-200 dark:border-green-700">
+          <h4 className="font-medium text-green-900 dark:text-green-200 mb-2">🥗 Dica Nutricional</h4>
+          <p className="text-sm text-green-700 dark:text-green-300">
+            Uma alimentação equilibrada é 70% do sucesso na perda de peso. Nosso plano será
             personalizado considerando suas preferências e restrições.
           </p>
         </div>

--- a/src/components/questionnaire/StepFour.tsx
+++ b/src/components/questionnaire/StepFour.tsx
@@ -55,7 +55,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="sedentario" id="nivel-sedentario" />
                     <div className="flex-1">
                       <Label htmlFor="nivel-sedentario" className="cursor-pointer font-medium">
@@ -64,7 +64,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                       <p className="text-sm text-gray-600">Pouca ou nenhuma atividade física</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="iniciante" id="nivel-iniciante" />
                     <div className="flex-1">
                       <Label htmlFor="nivel-iniciante" className="cursor-pointer font-medium">
@@ -73,7 +73,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                       <p className="text-sm text-gray-600">Exercícios leves e esporádicos</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="intermediario" id="nivel-intermediario" />
                     <div className="flex-1">
                       <Label htmlFor="nivel-intermediario" className="cursor-pointer font-medium">
@@ -82,7 +82,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                       <p className="text-sm text-gray-600">Exercícios regulares e moderados</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="avancado" id="nivel-avancado" />
                     <div className="flex-1">
                       <Label htmlFor="nivel-avancado" className="cursor-pointer font-medium">
@@ -118,7 +118,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                       return (
                         <FormItem
                           key={tipo.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -162,25 +162,25 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                   defaultValue={field.value}
                   className="grid grid-cols-1 md:grid-cols-2 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nunca" id="exp-nunca" />
                     <Label htmlFor="exp-nunca" className="cursor-pointer">
                       Nunca frequentei
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="pouca" id="exp-pouca" />
                     <Label htmlFor="exp-pouca" className="cursor-pointer">
                       Pouca experiência
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="moderada" id="exp-moderada" />
                     <Label htmlFor="exp-moderada" className="cursor-pointer">
                       Experiência moderada
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="muita" id="exp-muita" />
                     <Label htmlFor="exp-muita" className="cursor-pointer">
                       Muita experiência
@@ -213,7 +213,7 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                       return (
                         <FormItem
                           key={equipamento.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -257,25 +257,25 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
                   defaultValue={field.value}
                   className="grid grid-cols-1 md:grid-cols-2 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="casa" id="local-casa" />
                     <Label htmlFor="local-casa" className="cursor-pointer">
                       🏠 Em casa
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="academia" id="local-academia" />
                     <Label htmlFor="local-academia" className="cursor-pointer">
                       🏢 Academia
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="ar_livre" id="local-ar-livre" />
                     <Label htmlFor="local-ar-livre" className="cursor-pointer">
                       🌳 Ao ar livre
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="combinacao" id="local-combinacao" />
                     <Label htmlFor="local-combinacao" className="cursor-pointer">
                       🔄 Combinação
@@ -289,10 +289,10 @@ export default function StepFour({ form, onNext, onPrevious, canGoBack, defaultV
         />
 
         {/* Dica sobre exercícios */}
-        <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
-          <h4 className="font-medium text-blue-900 mb-2">💪 Dica de Treino</h4>
-          <p className="text-sm text-blue-700">
-            Não se preocupe se você é iniciante! Nosso plano será adaptado ao seu nível atual e 
+        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg border border-blue-200 dark:border-blue-700">
+          <h4 className="font-medium text-blue-900 dark:text-blue-200 mb-2">💪 Dica de Treino</h4>
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            Não se preocupe se você é iniciante! Nosso plano será adaptado ao seu nível atual e
             evoluirá gradualmente conforme você progride.
           </p>
         </div>

--- a/src/components/questionnaire/StepOne.tsx
+++ b/src/components/questionnaire/StepOne.tsx
@@ -24,8 +24,8 @@ export default function StepOne({ form, onNext, defaultValues }: StepProps) {
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
         {/* Título da Seção */}
         <div className="text-center">
-          <h2 className="text-2xl font-semibold text-gray-800 mb-2">Informações Pessoais</h2>
-          <p className="text-gray-600 text-sm">Preencha os dados para criar seu plano personalizado.</p>
+          <h2 className="text-2xl font-semibold text-gray-800 dark:text-gray-200 mb-2">Informações Pessoais</h2>
+          <p className="text-gray-600 dark:text-gray-400 text-sm">Preencha os dados para criar seu plano personalizado.</p>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
@@ -192,9 +192,9 @@ export default function StepOne({ form, onNext, defaultValues }: StepProps) {
         </div>
 
         {/* Dica */}
-        <div className="bg-blue-50 p-6 rounded-2xl flex flex-col gap-2">
-          <h4 className="font-medium text-blue-900 text-lg flex items-center gap-2">💡 Dica</h4>
-          <p className="text-sm text-blue-700 leading-relaxed">
+        <div className="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-2xl flex flex-col gap-2">
+          <h4 className="font-medium text-blue-900 dark:text-blue-200 text-lg flex items-center gap-2">💡 Dica</h4>
+          <p className="text-sm text-blue-700 dark:text-blue-300 leading-relaxed">
             Seja honesto com suas informações. Dados precisos nos ajudam a criar um plano mais eficaz para você.
           </p>
         </div>

--- a/src/components/questionnaire/StepSeven.tsx
+++ b/src/components/questionnaire/StepSeven.tsx
@@ -24,10 +24,10 @@ export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastS
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
         <div className="text-center mb-6">
           <BarChart3 className="w-12 h-12 text-blue-500 mx-auto mb-3" />
-          <h3 className="text-xl font-semibold text-gray-900 mb-2">
+          <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-200 mb-2">
             Dados Avançados (Opcional)
           </h3>
-          <p className="text-gray-600">
+          <p className="text-gray-600 dark:text-gray-400">
             Informações adicionais para um plano ainda mais preciso
           </p>
         </div>
@@ -189,22 +189,22 @@ export default function StepSeven({ form, onNext, onPrevious, canGoBack, isLastS
         />
 
         {/* Informação sobre dados opcionais */}
-        <div className="bg-blue-50 p-4 rounded-lg border border-blue-200">
-          <h4 className="font-medium text-blue-900 mb-2">📊 Dados Opcionais</h4>
-          <p className="text-sm text-blue-700">
-            Todos os campos desta etapa são opcionais. Quanto mais informações você fornecer, 
+        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg border border-blue-200 dark:border-blue-700">
+          <h4 className="font-medium text-blue-900 dark:text-blue-200 mb-2">📊 Dados Opcionais</h4>
+          <p className="text-sm text-blue-700 dark:text-blue-300">
+            Todos os campos desta etapa são opcionais. Quanto mais informações você fornecer,
             mais preciso e personalizado será seu plano de emagrecimento.
           </p>
         </div>
 
         {/* Resumo final */}
-        <div className="bg-green-50 p-6 rounded-lg border border-green-200 text-center">
+        <div className="bg-green-50 dark:bg-green-900/20 p-6 rounded-lg border border-green-200 dark:border-green-700 text-center">
           <CheckCircle className="w-12 h-12 text-green-500 mx-auto mb-3" />
-          <h4 className="font-semibold text-green-900 mb-2">
+          <h4 className="font-semibold text-green-900 dark:text-green-200 mb-2">
             Parabéns! Você está quase terminando!
           </h4>
-          <p className="text-sm text-green-700">
-            Após finalizar, processaremos todas as suas informações e criaremos um plano 
+          <p className="text-sm text-green-700 dark:text-green-300">
+            Após finalizar, processaremos todas as suas informações e criaremos um plano
             personalizado completo com treinos, dieta e acompanhamento.
           </p>
         </div>

--- a/src/components/questionnaire/StepSix.tsx
+++ b/src/components/questionnaire/StepSix.tsx
@@ -38,7 +38,7 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="saude" id="motiv-saude" />
                     <div className="flex-1">
                       <Label htmlFor="motiv-saude" className="cursor-pointer font-medium">
@@ -47,7 +47,7 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                       <p className="text-sm text-gray-600">Prevenir doenças e ter mais disposição</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="estetica" id="motiv-estetica" />
                     <div className="flex-1">
                       <Label htmlFor="motiv-estetica" className="cursor-pointer font-medium">
@@ -56,7 +56,7 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                       <p className="text-sm text-gray-600">Melhorar a aparência física</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="autoestima" id="motiv-autoestima" />
                     <div className="flex-1">
                       <Label htmlFor="motiv-autoestima" className="cursor-pointer font-medium">
@@ -65,7 +65,7 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                       <p className="text-sm text-gray-600">Sentir-se mais confiante</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="performance" id="motiv-performance" />
                     <div className="flex-1">
                       <Label htmlFor="motiv-performance" className="cursor-pointer font-medium">
@@ -74,7 +74,7 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                       <p className="text-sm text-gray-600">Ter mais energia e resistência</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="medica" id="motiv-medica" />
                     <div className="flex-1">
                       <Label htmlFor="motiv-medica" className="cursor-pointer font-medium">
@@ -105,19 +105,19 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="primeira" id="tent-primeira" />
                     <Label htmlFor="tent-primeira" className="cursor-pointer">
                       🆕 Esta é minha primeira tentativa
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="algumas" id="tent-algumas" />
                     <Label htmlFor="tent-algumas" className="cursor-pointer">
                       🔄 Já tentei algumas vezes
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="muitas" id="tent-muitas" />
                     <Label htmlFor="tent-muitas" className="cursor-pointer">
                       🔁 Já tentei muitas vezes
@@ -145,31 +145,31 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="tempo" id="dif-tempo" />
                     <Label htmlFor="dif-tempo" className="cursor-pointer">
                       ⏰ Falta de tempo
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="motivacao" id="dif-motivacao" />
                     <Label htmlFor="dif-motivacao" className="cursor-pointer">
                       😴 Falta de motivação
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="conhecimento" id="dif-conhecimento" />
                     <Label htmlFor="dif-conhecimento" className="cursor-pointer">
                       📚 Falta de conhecimento
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="disciplina" id="dif-disciplina" />
                     <Label htmlFor="dif-disciplina" className="cursor-pointer">
                       🎯 Falta de disciplina
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="resultados" id="dif-resultados" />
                     <Label htmlFor="dif-resultados" className="cursor-pointer">
                       📈 Resultados lentos
@@ -198,25 +198,25 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                   defaultValue={field.value}
                   className="grid grid-cols-1 md:grid-cols-2 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="muito" id="sup-muito" />
                     <Label htmlFor="sup-muito" className="cursor-pointer">
                       👨‍👩‍👧‍👦 Muito apoio da família/amigos
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="moderado" id="sup-moderado" />
                     <Label htmlFor="sup-moderado" className="cursor-pointer">
                       👥 Apoio moderado
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="pouco" id="sup-pouco" />
                     <Label htmlFor="sup-pouco" className="cursor-pointer">
                       👤 Pouco apoio
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nenhum" id="sup-nenhum" />
                     <Label htmlFor="sup-nenhum" className="cursor-pointer">
                       🚶 Nenhum apoio
@@ -247,19 +247,19 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="sim" id="exp-sim" />
                     <Label htmlFor="exp-sim" className="cursor-pointer">
                       ✅ Sim, tenho expectativas realistas
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nao" id="exp-nao" />
                     <Label htmlFor="exp-nao" className="cursor-pointer">
                       ⚡ Não, quero resultados rápidos
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nao_sei" id="exp-nao-sei" />
                     <Label htmlFor="exp-nao-sei" className="cursor-pointer">
                       🤔 Não sei, preciso de orientação
@@ -273,10 +273,10 @@ export default function StepSix({ form, onNext, onPrevious, canGoBack, defaultVa
         />
 
         {/* Mensagem motivacional */}
-        <div className="bg-purple-50 p-4 rounded-lg border border-purple-200">
-          <h4 className="font-medium text-purple-900 mb-2">🎯 Foco no Objetivo</h4>
-          <p className="text-sm text-purple-700">
-            Entender sua motivação e desafios nos ajuda a criar um plano que realmente funciona para você. 
+        <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded-lg border border-purple-200 dark:border-purple-700">
+          <h4 className="font-medium text-purple-900 dark:text-purple-200 mb-2">🎯 Foco no Objetivo</h4>
+          <p className="text-sm text-purple-700 dark:text-purple-300">
+            Entender sua motivação e desafios nos ajuda a criar um plano que realmente funciona para você.
             Lembre-se: pequenos passos consistentes levam a grandes transformações!
           </p>
         </div>

--- a/src/components/questionnaire/StepThree.tsx
+++ b/src/components/questionnaire/StepThree.tsx
@@ -46,7 +46,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
           name="tipo_trabalho"
           render={({ field }) => (
             <FormItem className="space-y-3">
-              <FormLabel className="text-base font-semibold flex items-center gap-2">
+              <FormLabel className="text-base font-semibold flex items-center gap-2 dark:text-gray-200">
                 <Clock className="w-5 h-5 text-blue-500" />
                 Tipo de trabalho *
               </FormLabel>
@@ -56,7 +56,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="sedentario" id="trabalho-sedentario" />
                     <div className="flex-1">
                       <Label htmlFor="trabalho-sedentario" className="cursor-pointer font-medium">
@@ -65,7 +65,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                       <p className="text-sm text-gray-600">Maior parte do dia sentado</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="moderado" id="trabalho-moderado" />
                     <div className="flex-1">
                       <Label htmlFor="trabalho-moderado" className="cursor-pointer font-medium">
@@ -74,7 +74,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                       <p className="text-sm text-gray-600">Algumas atividades em pé ou caminhando</p>
                     </div>
                   </div>
-                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-4 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="ativo" id="trabalho-ativo" />
                     <div className="flex-1">
                       <Label htmlFor="trabalho-ativo" className="cursor-pointer font-medium">
@@ -96,7 +96,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
           name="horarios_exercicio"
           render={() => (
             <FormItem>
-              <FormLabel className="text-base font-semibold">
+              <FormLabel className="text-base font-semibold dark:text-gray-200">
                 Horários disponíveis para exercício *
               </FormLabel>
               <p className="text-sm text-gray-600 mb-3">Selecione todos os horários que funcionam para você</p>
@@ -110,7 +110,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                       return (
                         <FormItem
                           key={horario.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -143,7 +143,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
           name="nivel_stress"
           render={({ field }) => (
             <FormItem className="space-y-4">
-              <FormLabel className="text-base font-semibold flex items-center gap-2">
+              <FormLabel className="text-base font-semibold flex items-center gap-2 dark:text-gray-200">
                 <Zap className="w-5 h-5 text-orange-500" />
                 Nível de stress (1-10) *
               </FormLabel>
@@ -177,7 +177,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
           name="qualidade_sono"
           render={({ field }) => (
             <FormItem className="space-y-3">
-              <FormLabel className="text-base font-semibold flex items-center gap-2">
+              <FormLabel className="text-base font-semibold flex items-center gap-2 dark:text-gray-200">
                 <Moon className="w-5 h-5 text-purple-500" />
                 Qualidade do sono *
               </FormLabel>
@@ -187,25 +187,25 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                   defaultValue={field.value}
                   className="grid grid-cols-1 md:grid-cols-2 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="excelente" id="sono-excelente" />
                     <Label htmlFor="sono-excelente" className="cursor-pointer">
                       Excelente (7-9h, sem interrupções)
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="boa" id="sono-boa" />
                     <Label htmlFor="sono-boa" className="cursor-pointer">
                       Boa (6-8h, poucas interrupções)
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="regular" id="sono-regular" />
                     <Label htmlFor="sono-regular" className="cursor-pointer">
                       Regular (5-7h, algumas interrupções)
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="ruim" id="sono-ruim" />
                     <Label htmlFor="sono-ruim" className="cursor-pointer">
                       Ruim (menos de 5h, muitas interrupções)
@@ -224,7 +224,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
           name="habitos_sociais"
           render={() => (
             <FormItem>
-              <FormLabel className="text-base font-semibold">Hábitos sociais</FormLabel>
+              <FormLabel className="text-base font-semibold dark:text-gray-200">Hábitos sociais</FormLabel>
               <p className="text-sm text-gray-600 mb-3">Selecione os que se aplicam (opcional)</p>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 {habitosSociais.map((habito) => (
@@ -236,7 +236,7 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
                       return (
                         <FormItem
                           key={habito.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -269,10 +269,10 @@ export default function StepThree({ form, onNext, onPrevious, canGoBack, default
         />
 
         {/* Dica sobre estilo de vida */}
-        <div className="bg-green-50 p-4 rounded-lg border border-green-200">
-          <h4 className="font-medium text-green-900 mb-2">🌱 Dica de Bem-estar</h4>
-          <p className="text-sm text-green-700">
-            Um bom sono e gerenciamento do stress são fundamentais para o sucesso na perda de peso. 
+        <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg border border-green-200 dark:border-green-700">
+          <h4 className="font-medium text-green-900 dark:text-green-200 mb-2">🌱 Dica de Bem-estar</h4>
+          <p className="text-sm text-green-700 dark:text-green-300">
+            Um bom sono e gerenciamento do stress são fundamentais para o sucesso na perda de peso.
             Nosso plano incluirá dicas específicas para seu estilo de vida.
           </p>
         </div>

--- a/src/components/questionnaire/StepTwo.tsx
+++ b/src/components/questionnaire/StepTwo.tsx
@@ -39,7 +39,7 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
           name="condicoes_medicas"
           render={() => (
             <FormItem>
-              <FormLabel className="text-base font-semibold flex items-center gap-2">
+              <FormLabel className="text-base font-semibold flex items-center gap-2 dark:text-gray-200">
                 <Heart className="w-5 h-5 text-red-500" />
                 Possui alguma condição médica? *
               </FormLabel>
@@ -53,7 +53,7 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
                       return (
                         <FormItem
                           key={condicao.id}
-                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50"
+                          className="flex flex-row items-start space-x-3 space-y-0 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700"
                         >
                           <FormControl>
                             <Checkbox
@@ -112,26 +112,26 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
           name="lesoes"
           render={({ field }) => (
             <FormItem className="space-y-3">
-              <FormLabel className="text-base font-semibold">Histórico de lesões? *</FormLabel>
+              <FormLabel className="text-base font-semibold dark:text-gray-200">Histórico de lesões? *</FormLabel>
               <FormControl>
                 <RadioGroup
                   onValueChange={field.onChange}
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nenhuma" id="lesoes-nenhuma" />
                     <Label htmlFor="lesoes-nenhuma" className="cursor-pointer">
                       Nenhuma lesão
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="leves" id="lesoes-leves" />
                     <Label htmlFor="lesoes-leves" className="cursor-pointer">
                       Lesões leves (já recuperadas)
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="atual" id="lesoes-atual" />
                     <Label htmlFor="lesoes-atual" className="cursor-pointer">
                       Lesão atual ou limitação
@@ -169,26 +169,26 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
           name="acompanhamento_medico"
           render={({ field }) => (
             <FormItem className="space-y-3">
-              <FormLabel className="text-base font-semibold">Acompanhamento médico atual? *</FormLabel>
+              <FormLabel className="text-base font-semibold dark:text-gray-200">Acompanhamento médico atual? *</FormLabel>
               <FormControl>
                 <RadioGroup
                   onValueChange={field.onChange}
                   defaultValue={field.value}
                   className="grid grid-cols-1 gap-3"
                 >
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="regular" id="acomp-regular" />
                     <Label htmlFor="acomp-regular" className="cursor-pointer">
                       Sim, tenho acompanhamento regular
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="esporadico" id="acomp-esporadico" />
                     <Label htmlFor="acomp-esporadico" className="cursor-pointer">
                       Esporádico
                     </Label>
                   </div>
-                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50">
+                  <div className="flex items-center space-x-3 p-3 border rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 dark:border-slate-700">
                     <RadioGroupItem value="nenhum" id="acomp-nenhum" />
                     <Label htmlFor="acomp-nenhum" className="cursor-pointer">
                       Não tenho acompanhamento
@@ -202,9 +202,9 @@ export default function StepTwo({ form, onNext, onPrevious, canGoBack, defaultVa
         />
 
         {/* Informação importante */}
-        <div className="bg-amber-50 p-4 rounded-lg border border-amber-200">
-          <h4 className="font-medium text-amber-900 mb-2">⚠️ Importante</h4>
-          <p className="text-sm text-amber-700">
+        <div className="bg-amber-50 dark:bg-amber-900/20 p-4 rounded-lg border border-amber-200 dark:border-amber-700">
+          <h4 className="font-medium text-amber-900 dark:text-amber-200 mb-2">⚠️ Importante</h4>
+          <p className="text-sm text-amber-700 dark:text-amber-300">
             Se você tem alguma condição médica ou lesão, recomendamos consultar um profissional de saúde antes de iniciar qualquer programa de exercícios.
           </p>
         </div>

--- a/src/components/ui/progress.jsx
+++ b/src/components/ui/progress.jsx
@@ -12,7 +12,7 @@ function Progress({
     <ProgressPrimitive.Root
       data-slot="progress"
       className={cn(
-        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        "bg-primary/20 dark:bg-primary/40 relative h-2 w-full overflow-hidden rounded-full",
         className
       )}
       {...props}>


### PR DESCRIPTION
## Summary
- improve readability of questionnaire steps in dark mode
- harmonize colors in help tips and navigation
- tweak progress component styling

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c07e53a648332ad0c5c8f16a664cf