### PR TITLE
Implement payment flow and plan restrictions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from './contexts/AuthContext';
 import ProtectedRoute from './components/ProtectedRoute';
 import AdminRoute from './components/AdminRoute';
 import Layout from './components/Layout/Layout';
+import PlanGuard from './components/PlanGuard';
 import Auth from './pages/Auth';
 import Home from './pages/Home';
 import Dashboard from './pages/Dashboard';
@@ -44,12 +45,33 @@ function App() {
             <Route path="store" element={<Store />} />
             <Route path="favorites" element={<Favorites />} />
             <Route path="profile" element={<Profile />} />
-            <Route path="progress" element={<Progress />} />
+            <Route
+              path="progress"
+              element={
+                <PlanGuard allowedPlans={["B", "C"]}>
+                  <Progress />
+                </PlanGuard>
+              }
+            />
             <Route path="plans" element={<Plans />} />
             <Route path="payment" element={<Payment />} />
             <Route path="settings" element={<Settings />} />
-            <Route path="apps" element={<AppsPage />} />
-            <Route path="emagrecimento" element={<Emagrecimento />} />
+            <Route
+              path="apps"
+              element={
+                <PlanGuard allowedPlans={["B", "C"]}>
+                  <AppsPage />
+                </PlanGuard>
+              }
+            />
+            <Route
+              path="emagrecimento"
+              element={
+                <PlanGuard allowedPlans={["B", "C"]}>
+                  <Emagrecimento />
+                </PlanGuard>
+              }
+            />
             <Route
               path="admin"
               element={

--- a/src/pages/Payment.tsx
+++ b/src/pages/Payment.tsx
@@ -29,6 +29,9 @@ const Payment: React.FC = () => {
   return (
     <div className="max-w-2xl mx-auto p-6 space-y-6">
       <h1 className="text-3xl font-bold text-slate-900 dark:text-white">Pagamento</h1>
+      {selectedPlan && (
+        <p className="text-slate-600 dark:text-slate-400">Você está adquirindo o <span className="font-medium">Plano {selectedPlan}</span></p>
+      )}
       <p className="text-slate-700 dark:text-slate-300">Escolha a forma de pagamento:</p>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
         <div className="flex flex-col items-center bg-slate-100 dark:bg-slate-800 p-4 rounded-xl">
@@ -53,7 +56,14 @@ const Payment: React.FC = () => {
       >
         <ExternalLink className="w-4 h-4 mr-2" /> Realizar Pagamento
       </button>
-    
+
+      <button
+        onClick={handleConfirm}
+        className="inline-flex items-center px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white rounded-lg"
+      >
+        <Check className="w-4 h-4 mr-2" /> Já paguei
+      </button>
+
       <Link to="/store" className="inline-flex items-center text-primary hover:underline">
         <ArrowLeft className="w-4 h-4 mr-2" /> Voltar para a loja
       </Link>


### PR DESCRIPTION
## Summary
- integrate `PlanGuard` with premium-only pages
- display selected plan on payment page
- add confirmation button for manual plan activation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c3308a6b48332b839822366a0c6ba