### PR TITLE
Fix profile settings icon

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -28,11 +28,10 @@ const Profile: React.FC = () => {
     name: user?.name || '',
     email: user?.email || '',
   });
-  const { metrics, setMetrics } = useProgressStore();
+  const { metrics } = useProgressStore();
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
-  const [bodyForm, setBodyForm] = useState(metrics);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];
@@ -44,7 +43,6 @@ const Profile: React.FC = () => {
 
   const handleSave = async () => {
     await updateUser({ name: formData.name, email: formData.email, file });
-    setMetrics(bodyForm);
     setIsEditing(false);
     setFile(null);
     setPreview(null);
@@ -55,7 +53,6 @@ const Profile: React.FC = () => {
       name: user?.name || '',
       email: user?.email || '',
     });
-    setBodyForm(metrics);
     setFile(null);
     setPreview(null);
     setIsEditing(false);
@@ -83,12 +80,12 @@ const Profile: React.FC = () => {
   ];
 
   const bodyMetrics = [
-    { label: 'Peso Corporal', value: bodyForm.totalWeight, unit: 'kg', trend: 'down' },
-    { label: 'IMC', value: bodyForm.bmi, unit: '', trend: 'stable' },
-    { label: 'Gordura Corporal', value: bodyForm.bodyFatPercent, unit: '%', trend: 'down' },
-    { label: 'Massa Muscular', value: bodyForm.skeletalMuscleMass, unit: 'kg', trend: 'up' },
-    { label: 'Água Corporal', value: bodyForm.totalBodyWater, unit: 'L', trend: 'stable' },
-    { label: 'TMB', value: bodyForm.bmr, unit: 'kcal', trend: 'up' },
+    { label: 'Peso Corporal', value: metrics.totalWeight, unit: 'kg', trend: 'down' },
+    { label: 'IMC', value: metrics.bmi, unit: '', trend: 'stable' },
+    { label: 'Gordura Corporal', value: metrics.bodyFatPercent, unit: '%', trend: 'down' },
+    { label: 'Massa Muscular', value: metrics.skeletalMuscleMass, unit: 'kg', trend: 'up' },
+    { label: 'Água Corporal', value: metrics.totalBodyWater, unit: 'L', trend: 'stable' },
+    { label: 'TMB', value: metrics.bmr, unit: 'kcal', trend: 'up' },
   ];
 
   const recentActivities = [
@@ -138,7 +135,6 @@ const Profile: React.FC = () => {
             {!isEditing ? (
               <button
                 onClick={() => {
-                  setBodyForm(metrics);
                   setIsEditing(true);
                 }}
                 className="flex items-center space-x-2 bg-gradient-to-r from-primary to-emerald-600 hover:from-primary-dark hover:to-emerald-700 text-white px-6 py-3 rounded-xl font-medium transition-all duration-200 hover:scale-105 shadow-lg hover:shadow-xl"
@@ -257,37 +253,6 @@ const Profile: React.FC = () => {
                       </div>
                     </div>
 
-                    {/* Métricas corporais em grid responsivo */}
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                      {[
-                        { label: 'Peso (kg)', key: 'totalWeight' },
-                        { label: 'IMC', key: 'bmi' },
-                        { label: 'Água Total (L)', key: 'totalBodyWater' },
-                        { label: 'Água Intracelular (L)', key: 'intracellularWater' },
-                        { label: 'Água Extracelular (L)', key: 'extracellularWater' },
-                        { label: 'Massa Magra (kg)', key: 'leanMass' },
-                        { label: 'Massa Muscular (kg)', key: 'skeletalMuscleMass' },
-                        { label: 'Massa de Gordura (kg)', key: 'bodyFatMass' },
-                        { label: '% Gordura Corporal', key: 'bodyFatPercent' },
-                        { label: 'Gordura Braços (%)', key: 'fatArms' },
-                        { label: 'Gordura Tronco (%)', key: 'fatTrunk' },
-                        { label: 'Gordura Pernas (%)', key: 'fatLegs' },
-                        { label: 'Massa Óssea (kg)', key: 'boneMass' },
-                        { label: 'TMB (kcal)', key: 'bmr' },
-                        { label: 'Relação ECW/ICW', key: 'ecwIcwRatio' },
-                        { label: 'Equilíbrio Muscular (%)', key: 'muscleSymmetry' },
-                      ].map((field) => (
-                        <div key={field.key} className="space-y-2">
-                          <label className="block text-sm font-medium text-slate-300">{field.label}</label>
-                          <input
-                            type="number"
-                            value={bodyForm[field.key as keyof typeof bodyForm]}
-                            onChange={(e) => setBodyForm({ ...bodyForm, [field.key]: Number(e.target.value) })}
-                            className="w-full bg-slate-700/50 border border-slate-600 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all duration-200"
-                          />
-                        </div>
-                      ))}
-                    </div>
                   </div>
                 )}
               </div>
@@ -436,21 +401,24 @@ const Profile: React.FC = () => {
                   { title: 'Privacidade', description: 'Controle suas configurações de privacidade', icon: Shield },
                   { title: 'Metas', description: 'Defina e acompanhe suas metas pessoais', icon: Target },
                   { title: 'Conta', description: 'Configurações da sua conta', icon: User },
-                ].map((setting, index) => (
-                  <div
-                    key={index}
-                    className="flex items-center justify-between p-4 bg-slate-700/30 rounded-xl hover:bg-slate-700/50 transition-all duration-200 group cursor-pointer"
-                  >
-                    <div className="flex items-center space-x-4">
-                      <setting.icon className="w-6 h-6 text-slate-400 group-hover:text-white transition-colors duration-200" />
-                      <div>
-                        <div className="text-white font-medium">{setting.title}</div>
-                        <div className="text-slate-400 text-sm">{setting.description}</div>
+                ].map((setting, index) => {
+                  const Icon = setting.icon;
+                  return (
+                    <div
+                      key={index}
+                      className="flex items-center justify-between p-4 bg-slate-700/30 rounded-xl hover:bg-slate-700/50 transition-all duration-200 group cursor-pointer"
+                    >
+                      <div className="flex items-center space-x-4">
+                        <Icon className="w-6 h-6 text-slate-400 group-hover:text-white transition-colors duration-200" />
+                        <div>
+                          <div className="text-white font-medium">{setting.title}</div>
+                          <div className="text-slate-400 text-sm">{setting.description}</div>
+                        </div>
                       </div>
+                      <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-white group-hover:translate-x-1 transition-all duration-200" />
                     </div>
-                    <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-white group-hover:translate-x-1 transition-all duration-200" />
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </section>
           )}

--- a/src/pages/Progress.tsx
+++ b/src/pages/Progress.tsx
@@ -4,8 +4,20 @@ import { useProgressStore } from '../stores/progressStore';
 import Report from '../components/Report';
 
 const Progress: React.FC = () => {
-  const { weightLoss, metrics, reportData } = useProgressStore();
+  const { weightLoss, metrics, reportData, setMetrics } = useProgressStore();
   const [showReport, setShowReport] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [formMetrics, setFormMetrics] = useState(metrics);
+
+  const handleSaveMetrics = () => {
+    setMetrics(formMetrics);
+    setIsEditing(false);
+  };
+
+  const handleCancel = () => {
+    setFormMetrics(metrics);
+    setIsEditing(false);
+  };
 
   return (
     <div className="space-y-6">
@@ -33,60 +45,124 @@ const Progress: React.FC = () => {
       )}
 
       <section className="bg-slate-800 rounded-lg p-6 space-y-4">
-        <h2 className="text-xl font-semibold text-white mb-4">Composição Corporal</h2>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-slate-300">
-          <div>
-            <span className="font-medium text-white">Peso Corporal:</span> {metrics.totalWeight}kg
-          </div>
-          <div>
-            <span className="font-medium text-white">IMC:</span> {metrics.bmi}
-          </div>
-          <div>
-            <span className="font-medium text-white">Água Corporal Total:</span> {metrics.totalBodyWater}L
-          </div>
-          <div>
-            <span className="font-medium text-white">Água Intracelular:</span> {metrics.intracellularWater}L
-          </div>
-          <div>
-            <span className="font-medium text-white">Água Extracelular:</span> {metrics.extracellularWater}L
-          </div>
-          <div>
-            <span className="font-medium text-white">Massa Magra:</span> {metrics.leanMass}kg
-          </div>
-          <div>
-            <span className="font-medium text-white">Massa Muscular Esquelética:</span> {metrics.skeletalMuscleMass}kg
-          </div>
-          <div>
-            <span className="font-medium text-white">Massa de Gordura:</span> {metrics.bodyFatMass}kg
-          </div>
-          <div>
-            <span className="font-medium text-white">% Gordura Corporal:</span> {metrics.bodyFatPercent}%
-          </div>
-          <div>
-            <span className="font-medium text-white">Gordura Braços:</span> {metrics.fatArms}%
-          </div>
-          <div>
-            <span className="font-medium text-white">Gordura Tronco:</span> {metrics.fatTrunk}%
-          </div>
-          <div>
-            <span className="font-medium text-white">Gordura Pernas:</span> {metrics.fatLegs}%
-          </div>
-          <div>
-            <span className="font-medium text-white">Massa Óssea:</span> {metrics.boneMass}kg
-          </div>
-          <div>
-            <span className="font-medium text-white">TMB:</span> {weightLoss?.tmb ?? metrics.bmr} kcal
-          </div>
-          <div>
-            <span className="font-medium text-white">Calorias Diárias:</span> {weightLoss?.caloriasDiarias ?? 0} kcal
-          </div>
-          <div>
-            <span className="font-medium text-white">Relação ECW/ICW:</span> {metrics.ecwIcwRatio}
-          </div>
-          <div>
-            <span className="font-medium text-white">Equilíbrio Muscular:</span> {metrics.muscleSymmetry}%
-          </div>
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-semibold text-white">Composição Corporal</h2>
+          {!isEditing ? (
+            <button
+              onClick={() => {
+                setFormMetrics(metrics);
+                setIsEditing(true);
+              }}
+              className="text-sm text-primary hover:underline"
+            >
+              Editar
+            </button>
+          ) : (
+            <div className="space-x-2">
+              <button
+                onClick={handleSaveMetrics}
+                className="px-3 py-1 rounded-md bg-primary text-white text-sm"
+              >
+                Salvar
+              </button>
+              <button
+                onClick={handleCancel}
+                className="px-3 py-1 rounded-md bg-slate-600 text-white text-sm"
+              >
+                Cancelar
+              </button>
+            </div>
+          )}
         </div>
+
+        {isEditing ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[
+              { label: 'Peso (kg)', key: 'totalWeight' },
+              { label: 'IMC', key: 'bmi' },
+              { label: 'Água Total (L)', key: 'totalBodyWater' },
+              { label: 'Água Intracelular (L)', key: 'intracellularWater' },
+              { label: 'Água Extracelular (L)', key: 'extracellularWater' },
+              { label: 'Massa Magra (kg)', key: 'leanMass' },
+              { label: 'Massa Muscular (kg)', key: 'skeletalMuscleMass' },
+              { label: 'Massa de Gordura (kg)', key: 'bodyFatMass' },
+              { label: '% Gordura Corporal', key: 'bodyFatPercent' },
+              { label: 'Gordura Braços (%)', key: 'fatArms' },
+              { label: 'Gordura Tronco (%)', key: 'fatTrunk' },
+              { label: 'Gordura Pernas (%)', key: 'fatLegs' },
+              { label: 'Massa Óssea (kg)', key: 'boneMass' },
+              { label: 'TMB (kcal)', key: 'bmr' },
+              { label: 'Relação ECW/ICW', key: 'ecwIcwRatio' },
+              { label: 'Equilíbrio Muscular (%)', key: 'muscleSymmetry' },
+            ].map((field) => (
+              <div key={field.key} className="space-y-2">
+                <label className="block text-sm font-medium text-slate-300">{field.label}</label>
+                <input
+                  type="number"
+                  value={formMetrics[field.key as keyof typeof formMetrics]}
+                  onChange={(e) =>
+                    setFormMetrics({ ...formMetrics, [field.key]: Number(e.target.value) })
+                  }
+                  className="w-full bg-slate-700/50 border border-slate-600 rounded-xl px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all duration-200"
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 text-slate-300">
+            <div>
+              <span className="font-medium text-white">Peso Corporal:</span> {metrics.totalWeight}kg
+            </div>
+            <div>
+              <span className="font-medium text-white">IMC:</span> {metrics.bmi}
+            </div>
+            <div>
+              <span className="font-medium text-white">Água Corporal Total:</span> {metrics.totalBodyWater}L
+            </div>
+            <div>
+              <span className="font-medium text-white">Água Intracelular:</span> {metrics.intracellularWater}L
+            </div>
+            <div>
+              <span className="font-medium text-white">Água Extracelular:</span> {metrics.extracellularWater}L
+            </div>
+            <div>
+              <span className="font-medium text-white">Massa Magra:</span> {metrics.leanMass}kg
+            </div>
+            <div>
+              <span className="font-medium text-white">Massa Muscular Esquelética:</span> {metrics.skeletalMuscleMass}kg
+            </div>
+            <div>
+              <span className="font-medium text-white">Massa de Gordura:</span> {metrics.bodyFatMass}kg
+            </div>
+            <div>
+              <span className="font-medium text-white">% Gordura Corporal:</span> {metrics.bodyFatPercent}%
+            </div>
+            <div>
+              <span className="font-medium text-white">Gordura Braços:</span> {metrics.fatArms}%
+            </div>
+            <div>
+              <span className="font-medium text-white">Gordura Tronco:</span> {metrics.fatTrunk}%
+            </div>
+            <div>
+              <span className="font-medium text-white">Gordura Pernas:</span> {metrics.fatLegs}%
+            </div>
+            <div>
+              <span className="font-medium text-white">Massa Óssea:</span> {metrics.boneMass}kg
+            </div>
+            <div>
+              <span className="font-medium text-white">TMB:</span> {weightLoss?.tmb ?? metrics.bmr} kcal
+            </div>
+            <div>
+              <span className="font-medium text-white">Calorias Diárias:</span> {weightLoss?.caloriasDiarias ?? 0} kcal
+            </div>
+            <div>
+              <span className="font-medium text-white">Relação ECW/ICW:</span> {metrics.ecwIcwRatio}
+            </div>
+            <div>
+              <span className="font-medium text-white">Equilíbrio Muscular:</span> {metrics.muscleSymmetry}%
+            </div>
+          </div>
+        )}
       </section>
       {showReport && weightLoss && (
         <div className="fixed inset-0 z-10 bg-black/70 flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- fix dynamic Icon usage in Profile settings menu
- move body metrics editing to progress page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686c4b9573bc83329e6012e97c9ea69a