### PR TITLE
Add plan bypass option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,6 @@ VITE_FIREBASE_PROJECT_ID=your_project_id
 VITE_FIREBASE_STORAGE_BUCKET=your_project.appspot.com
 VITE_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 VITE_FIREBASE_APP_ID=your_app_id
+
+# Bypass plan restriction during development
+VITE_BYPASS_PLAN_GUARD=false

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Plataforma web desenvolvida em React + TypeScript para gerenciamento de vídeos 
 VITE_API_URL=http://localhost:3000/api
 VITE_ADMIN_EMAIL=admin@seuauge.com
 VITE_PAYMENT_URL=https://pagamento.exemplo.com
+VITE_BYPASS_PLAN_GUARD=true
 ```
 
 ## Instalação

--- a/src/components/PlanGuard.tsx
+++ b/src/components/PlanGuard.tsx
@@ -3,13 +3,23 @@ import React from 'react';
 import { useLocation, Navigate } from 'react-router-dom';
 import usePlan from '../hooks/usePlan';
 
+const BYPASS_PLAN_GUARD = import.meta.env.VITE_BYPASS_PLAN_GUARD === 'true';
+
 interface PlanGuardProps {
   allowedPlans: string[];
   redirectTo?: string;
   children: React.ReactNode;
 }
 
-const PlanGuard: React.FC<PlanGuardProps> = ({ allowedPlans, redirectTo = '/payment', children }) => {
+const PlanGuard: React.FC<PlanGuardProps> = ({
+  allowedPlans,
+  redirectTo = '/payment',
+  children,
+}) => {
+  if (BYPASS_PLAN_GUARD) {
+    return <>{children}</>;
+  }
+
   const { plan, loading } = usePlan();
   const location = useLocation();
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,9 @@ interface ImportMetaEnv {
   readonly VITE_FIREBASE_MESSAGING_SENDER_ID: string;
   readonly VITE_FIREBASE_APP_ID: string;
   readonly VITE_API_URL?: string;
+  readonly VITE_PAYMENT_URL?: string;
+  readonly VITE_ADMIN_EMAIL?: string;
+  readonly VITE_BYPASS_PLAN_GUARD?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- allow bypassing plan check with `VITE_BYPASS_PLAN_GUARD`
- document bypass variable in README and `.env.example`
- extend `vite-env.d.ts`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686c71e5057083329c429a7aa1f415a7