### PR TITLE
Add missing PlansSection component

### DIFF
--- a/src/components/home/PlansSection.tsx
+++ b/src/components/home/PlansSection.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function PlansSection() {
+  return (
+    <div>
+      Plans Section Placeholder
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `PlansSection` placeholder component under `src/components/home`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d9a7a54e883329c54e1dfe4624df8