### PR TITLE
Implementa gestão de planos no Firebase e melhorias no perfil

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -49,7 +49,8 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(true);
 
   const mapFirebaseUser = async (firebaseUser: FirebaseUser): Promise<User> => {
-    const plan = await getPlanFromToken();
+    const planFromToken = await getPlanFromToken();
+    const plan = planFromToken ?? 'A';
     return {
       id: firebaseUser.uid,
       email: firebaseUser.email || '',
@@ -92,7 +93,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       if (auth.currentUser) {
         await updateProfile(auth.currentUser, { displayName: name });
       }
-      await createUserDocument({ uid: cred.user.uid, name, email });
+      await createUserDocument({ uid: cred.user.uid, name, email, plan: 'A' });
       const mapped = await mapFirebaseUser(cred.user);
       setUser(mapped);
       console.log('Usuário registrado', mapped.email);

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -7,7 +7,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyDttKYZ1bQEzEzK43y1qQo8z9g3cG-N2Ss",
   authDomain: "seuaugesys.firebaseapp.com",
   projectId: "seuaugesys",
-  storageBucket: "seuaugesys.firebasestorage.app",
+  storageBucket: "seuaugesys.appspot.com",
   messagingSenderId: "359671420554",
   appId: "1:359671420554:web:86208860508a4db80a7f73",
 

--- a/src/services/plan.ts
+++ b/src/services/plan.ts
@@ -1,5 +1,18 @@
-import { auth } from '../firebase';
+import { auth, db } from '../firebase';
 import api from './api';
+import { collection, getDocs, doc, setDoc } from 'firebase/firestore';
+
+export interface PlanData {
+  id: string;
+  name: string;
+  price: string;
+  features: string[];
+}
+
+export async function getPlans(): Promise<PlanData[]> {
+  const snapshot = await getDocs(collection(db, 'plans'));
+  return snapshot.docs.map((d) => d.data() as PlanData);
+}
 
 export async function getPlanFromToken(forceRefresh = false): Promise<string | null> {
   const currentUser = auth.currentUser;
@@ -14,4 +27,7 @@ export async function updateUserPlan(plan: string): Promise<void> {
     method: 'POST',
     body: JSON.stringify({ plan }),
   });
+  if (auth.currentUser) {
+    await setDoc(doc(db, 'users', auth.currentUser.uid), { plan }, { merge: true });
+  }
 }

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -14,6 +14,7 @@ export interface CreateUserInput {
   name: string;
   email: string;
   avatar?: string | null;
+  plan?: string;
 }
 
 export async function updateUserProfile({ name, email, file }: UpdateUserInput) {
@@ -51,6 +52,7 @@ export async function createUserDocument({
   name,
   email,
   avatar = null,
+  plan = 'A',
 }: CreateUserInput) {
-  await setDoc(doc(db, 'users', uid), { name, email, avatar });
+  await setDoc(doc(db, 'users', uid), { name, email, avatar, plan });
 }


### PR DESCRIPTION
## Summary
- corrige bucket do Firebase
- armazena plano padrão ao criar usuário
- implementa serviços para buscar e atualizar planos no Firestore
- ajusta mapeamento do usuário para plano padrão
- atualiza página de perfil com cancelamento de assinatura e correções de edição

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686e5cc27f708332b510b11e208ccfb2