### PR TITLE
Fix Profile updates with new toast feedback

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-hook-form": "^7.59.0",
     "react-router-dom": "^6.22.0",
     "recharts": "^3.0.2",
+    "react-hot-toast": "^2.4.1",
     "zod": "^3.25.73",
     "zustand": "^4.5.0"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Settings from './pages/Settings';
 import Payment from './pages/Payment';
 import Plans from './pages/Plans';
 import AdminDashboard from './pages/AdminDashboard';
+import { Toaster } from 'react-hot-toast';
 const Progress = lazy(() => import('./pages/Progress'));
 const AppsPage = lazy(() => import('./pages/Apps'));
 import About from './pages/About';
@@ -90,8 +91,8 @@ function App() {
           </Route>
         </Routes>
       </div>
+      <Toaster position="top-right" />
     </AuthProvider>
   );
 }
-
 export default App;


### PR DESCRIPTION
## Summary
- use `react-hot-toast` for profile save notifications and loading state
- ensure file upload accepts only image files
- render `Toaster` at app root
- add `react-hot-toast` dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e7c1550388332adfe1f1e72731eae