### PR TITLE
Persist user body metrics

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { 
   User, 
   Camera, 
@@ -19,6 +19,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { useProgressStore } from '../stores/progressStore';
+import { getUserMetrics } from '../services/user';
 
 const Profile: React.FC = () => {
   const { user, updateUser } = useAuth();
@@ -28,10 +29,21 @@ const Profile: React.FC = () => {
     name: user?.name || '',
     email: user?.email || '',
   });
-  const { metrics } = useProgressStore();
+  const { metrics, setMetrics } = useProgressStore();
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!user) return;
+    async function loadMetrics() {
+      const saved = await getUserMetrics();
+      if (saved) {
+        setMetrics(saved);
+      }
+    }
+    loadMetrics();
+  }, [user, setMetrics]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selected = e.target.files?.[0];

--- a/src/pages/Progress.tsx
+++ b/src/pages/Progress.tsx
@@ -1,15 +1,31 @@
-import React, { useState, lazy, Suspense } from 'react';
+import React, { useState, lazy, Suspense, useEffect } from 'react';
 import { TrendingUp } from 'lucide-react';
 import { useProgressStore } from '../stores/progressStore';
+import { useAuth } from '../contexts/AuthContext';
+import { getUserMetrics, updateUserMetrics } from '../services/user';
 const Report = lazy(() => import('../components/Report'));
 
 const Progress: React.FC = () => {
   const { weightLoss, metrics, reportData, setMetrics } = useProgressStore();
+  const { user } = useAuth();
   const [showReport, setShowReport] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [formMetrics, setFormMetrics] = useState(metrics);
 
-  const handleSaveMetrics = () => {
+  useEffect(() => {
+    if (!user) return;
+    async function load() {
+      const saved = await getUserMetrics();
+      if (saved) {
+        setMetrics(saved);
+        setFormMetrics(saved);
+      }
+    }
+    load();
+  }, [user, setMetrics]);
+
+  const handleSaveMetrics = async () => {
+    await updateUserMetrics(formMetrics);
     setMetrics(formMetrics);
     setIsEditing(false);
   };


### PR DESCRIPTION
## Summary
- save body metrics on user document and retrieve later
- load metrics on profile and progress pages
- show user name in profile by default

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e902816748332b88ccaf2b20b163d