### PR TITLE
Implement profile and registration validations

### DIFF
--- a/src/components/Auth/RegisterForm.tsx
+++ b/src/components/Auth/RegisterForm.tsx
@@ -14,13 +14,44 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { register } = useAuth();
+  const [birthdate, setBirthdate] = useState('');
+  const [weight, setWeight] = useState('');
+  const [height, setHeight] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+
+    if (name.trim().length < 2 || name.trim().length > 50) {
+      alert('Nome deve ter entre 2 e 50 caracteres');
+      setLoading(false);
+      return;
+    }
+
+    const pesoNum = Number(weight);
+    if (pesoNum < 30 || pesoNum > 300) {
+      alert('Peso deve estar entre 30kg e 300kg');
+      setLoading(false);
+      return;
+    }
+
+    const alturaNum = Number(height);
+    if (alturaNum < 100 || alturaNum > 250) {
+      alert('Altura deve estar entre 100 e 250 cm');
+      setLoading(false);
+      return;
+    }
+
+    const birth = new Date(birthdate);
+    const age = new Date().getFullYear() - birth.getFullYear();
+    if (age > 100 || age < 16) {
+      alert('Idade deve estar entre 16 e 100 anos.');
+      setLoading(false);
+      return;
+    }
     
     try {
-      await register(email, password, name);
+      await register(email, password, name, birthdate);
       setError(null);
     } catch (error) {
       console.error('Erro no cadastro:', error);
@@ -103,6 +134,84 @@ const RegisterForm: React.FC<RegisterFormProps> = ({ onToggleMode }) => {
               {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
             </button>
           </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">
+            Data de Nascimento
+          </label>
+          <input
+            type="date"
+            value={birthdate}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setBirthdate(e.target.value);
+              setError(null);
+            }}
+            className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+            required
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-2">
+              Peso (kg)
+            </label>
+            <input
+              type="number"
+              value={weight}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const val = Number(e.target.value);
+                if (val < 30 || val > 300) {
+                  alert('Peso deve estar entre 30kg e 300kg');
+                  return;
+                }
+                setWeight(e.target.value);
+                setError(null);
+              }}
+              className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-2">
+              Altura (cm)
+            </label>
+            <input
+              type="number"
+              value={height}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const val = Number(e.target.value);
+                if (val < 100 || val > 250) {
+                  alert('Altura deve estar entre 100 e 250 cm');
+                  return;
+                }
+                setHeight(e.target.value);
+                setError(null);
+              }}
+              className="w-full px-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
+              required
+            />
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-slate-300 mb-2">
+            IMC
+          </label>
+          <input
+            type="text"
+            value={
+              weight && height
+                ? (
+                    Number(weight) /
+                    Math.pow(Number(height) / 100, 2)
+                  ).toFixed(1)
+                : ''
+            }
+            readOnly
+            className="w-full px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white"
+          />
         </div>
 
         {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -27,7 +27,12 @@ interface User {
 interface AuthContextType {
   user: User | null;
   login: (email: string, password: string) => Promise<void>;
-  register: (email: string, password: string, name: string) => Promise<void>;
+  register: (
+    email: string,
+    password: string,
+    name: string,
+    birthdate: string
+  ) => Promise<void>;
   logout: () => void;
   updateUser: (data: UpdateUserInput) => Promise<void>;
   refreshPlan: () => Promise<void>;
@@ -86,13 +91,18 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     }
   };
 
-  const register = async (email: string, password: string, name: string) => {
+  const register = async (
+    email: string,
+    password: string,
+    name: string,
+    birthdate: string
+  ) => {
     try {
       const cred = await createUserWithEmailAndPassword(auth, email, password);
       if (auth.currentUser) {
         await updateProfile(auth.currentUser, { displayName: name });
       }
-      await createUserDocument({ uid: cred.user.uid, name, email });
+      await createUserDocument({ uid: cred.user.uid, name, email, birthdate });
       const mapped = await mapFirebaseUser(cred.user);
       setUser(mapped);
       console.log('Usuário registrado', mapped.email);

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -6,7 +6,8 @@ import type { BodyMetrics } from '../stores/progressStore';
 
 export interface UpdateUserInput {
   name: string;
-  email: string;
+  email?: string;
+  birthdate?: string;
   file?: File | null;
 }
 
@@ -15,9 +16,10 @@ export interface CreateUserInput {
   name: string;
   email: string;
   avatar?: string | null;
+  birthdate?: string | null;
 }
 
-export async function updateUserProfile({ name, email, file }: UpdateUserInput) {
+export async function updateUserProfile({ name, email, birthdate, file }: UpdateUserInput) {
   if (!auth.currentUser) return;
 
   let photoURL = auth.currentUser.photoURL || undefined;
@@ -33,11 +35,13 @@ export async function updateUserProfile({ name, email, file }: UpdateUserInput) 
     photoURL: photoURL ?? null,
   });
 
-  if (auth.currentUser.email !== email) {
+  if (email && auth.currentUser.email !== email) {
     await updateEmail(auth.currentUser, email);
   }
 
-  const data: Record<string, unknown> = { name, email };
+  const data: Record<string, unknown> = { name };
+  if (email) data.email = email;
+  if (birthdate) data.birthdate = birthdate;
   if (photoURL !== undefined) {
     data.avatar = photoURL;
   }
@@ -52,8 +56,9 @@ export async function createUserDocument({
   name,
   email,
   avatar = null,
+  birthdate = null,
 }: CreateUserInput) {
-  await setDoc(doc(db, 'users', uid), { name, email, avatar });
+  await setDoc(doc(db, 'users', uid), { name, email, avatar, birthdate });
 }
 
 export async function updateUserMetrics(metrics: BodyMetrics) {


### PR DESCRIPTION
## Summary
- fetch Firestore profile data on profile page
- add birthdate and body info fields
- validate inputs on profile and registration forms
- store birthdate in user documents
- update auth context and services for new data

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686e95fb2eec83329a8926696d9db30c