### PR TITLE
Show plan name on header and sidebar badges

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -3,6 +3,7 @@ import { Search, ShoppingCart, Bell, Menu, User } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import { useCartStore } from '../../stores/cartStore';
+import { PLANS } from '../../data/plans';
 
 interface HeaderProps {
   onMenuClick: () => void;
@@ -12,6 +13,8 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
   const { user } = useAuth();
   const { getTotalItems, toggleCart, showAddedAnimation } = useCartStore();
   const [searchQuery, setSearchQuery] = useState('');
+
+  const planName = PLANS.find((p) => p.id === (user?.plan ?? 'A'))?.name ?? 'Gratuito';
 
   const totalCartItems = getTotalItems();
 
@@ -74,7 +77,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
           >
             <div className="hidden sm:block text-right">
               <p className="text-sm font-medium text-slate-900 dark:text-white">{user?.name}</p>
-              <p className="text-xs text-slate-600 dark:text-slate-400">Membro Premium</p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">{planName}</p>
             </div>
             <div className="w-8 h-8 rounded-full overflow-hidden bg-gradient-to-r from-teal-500 to-emerald-500 flex items-center justify-center">
               {user?.avatar ? (
@@ -89,5 +92,4 @@ const Header: React.FC<HeaderProps> = ({ onMenuClick }) => {
     </header>
   );
 };
-
 export default Header;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   ShieldCheck
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
+import { PLANS } from '../../data/plans';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -23,6 +24,7 @@ interface SidebarProps {
 const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const location = useLocation();
   const { user, logout } = useAuth();
+  const planName = PLANS.find((p) => p.id === (user?.plan ?? 'A'))?.name ?? 'Gratuito';
 
   const menuItems = [
     { icon: Home, label: 'Início', path: '/dashboard' },
@@ -96,15 +98,15 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
           </div>
         </nav>
 
-        {/* Premium Badge */}
+        {/* Plan Badge */}
         <div className="mx-4 mt-8 p-4 bg-gradient-to-r from-yellow-500/10 to-orange-500/10 border border-yellow-500/20 rounded-xl">
           <div className="flex items-center space-x-3">
             <div className="w-8 h-8 bg-gradient-to-r from-yellow-500 to-orange-500 rounded-lg flex items-center justify-center">
               <Sparkles className="w-4 h-4 text-white" />
             </div>
             <div>
-              <p className="text-sm font-medium text-slate-900 dark:text-white">Premium</p>
-              <p className="text-xs text-slate-600 dark:text-slate-400">Acesso total</p>
+              <p className="text-sm font-medium text-slate-900 dark:text-white">{planName}</p>
+              <p className="text-xs text-slate-600 dark:text-slate-400">Plano atual</p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- display the user plan name in Header and Sidebar
- remove static "Membro Premium" and "Premium Acesso total" labels

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_686eb399c9048332a0b5b53a271403f4