### PR TITLE
Add coming soon placeholder for store

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ VITE_SENTRY_DSN=
 
 # Bypass plan restriction during development
 VITE_BYPASS_PLAN_GUARD=false
+
+# Enable store and products features
+VITE_STORE_ENABLED=false

--- a/src/components/Common/ComingSoon.tsx
+++ b/src/components/Common/ComingSoon.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Clock } from 'lucide-react';
+
+interface ComingSoonProps {
+  title?: string;
+  description?: string;
+}
+
+const ComingSoon: React.FC<ComingSoonProps> = ({
+  title = 'Em breve',
+  description = 'Estamos trabalhando para disponibilizar esta funcionalidade em breve.'
+}) => (
+  <div className="flex flex-col items-center justify-center py-20 text-center space-y-4">
+    <Clock className="w-16 h-16 text-primary" />
+    <h1 className="text-3xl font-bold text-white">{title}</h1>
+    <p className="text-slate-400 max-w-md">{description}</p>
+  </div>
+);
+
+export default ComingSoon;

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
 } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { PLANS } from '../../data/plans';
+import { storeEnabled } from '../../lib/config';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -29,7 +30,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
   const menuItems = [
     { icon: Home, label: 'Início', path: '/dashboard' },
     { icon: Play, label: 'Vídeos', path: '/videos' },
-    { icon: ShoppingBag, label: 'Loja', path: '/store' },
+    { icon: ShoppingBag, label: 'Loja', path: '/store', disabled: !storeEnabled },
     { icon: Sparkles, label: 'Planos', path: '/plans' },
     { icon: Heart, label: 'Favoritos', path: '/favorites' },
     { icon: TrendingUp, label: 'Progresso', path: '/progress' },
@@ -74,18 +75,30 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose }) => {
           <div className="space-y-2">
             {menuItems.map((item) => {
               const Icon = item.icon;
+              const baseClasses = `
+                flex items-center px-4 py-3 rounded-xl transition-all duration-200 group
+                ${isActive(item.path)
+                  ? 'bg-gradient-to-r from-primary to-emerald-600 text-white shadow-lg shadow-primary-dark/25'
+                  : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800/50'}
+                ${item.disabled ? 'pointer-events-none opacity-50' : ''}
+              `;
+
+              if (item.disabled) {
+                return (
+                  <div key={item.path} className={baseClasses}>
+                    <Icon className="w-5 h-5 mr-4 text-slate-600 dark:text-slate-400" />
+                    <span className="font-medium">{item.label}</span>
+                    <span className="ml-auto text-xs text-slate-400">Em breve</span>
+                  </div>
+                );
+              }
+
               return (
                 <Link
                   key={item.path}
                   to={item.path}
                   onClick={onClose}
-                  className={`
-                    flex items-center px-4 py-3 rounded-xl transition-all duration-200 group
-                    ${isActive(item.path)
-                      ? 'bg-gradient-to-r from-primary to-emerald-600 text-white shadow-lg shadow-primary-dark/25'
-                      : 'text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white hover:bg-slate-200 dark:hover:bg-slate-800/50'
-                    }
-                  `}
+                  className={baseClasses}
                 >
                   <Icon className={`w-5 h-5 mr-4 ${isActive(item.path) ? 'text-white' : 'text-slate-600 dark:text-slate-400 group-hover:text-primary'}`} />
                   <span className="font-medium">{item.label}</span>

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,1 @@
+export const storeEnabled = import.meta.env.VITE_STORE_ENABLED === 'true';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,6 +5,8 @@ import ProductCard from '../components/Products/ProductCard';
 import { mockProducts } from '../data/mockData';
 import AppCard from '../components/Apps/AppCard';
 import { apps } from '../data/apps';
+import ComingSoon from '../components/Common/ComingSoon';
+import { storeEnabled } from '../lib/config';
 
 const Dashboard: React.FC = () => {
   
@@ -59,17 +61,27 @@ const Dashboard: React.FC = () => {
       <section>
         <div className="flex items-center justify-between mb-6">
           <h2 className="text-2xl font-bold text-white">Loja de Produtos de Saúde</h2>
-          <button className="text-primary hover:text-primary font-medium">Ver Todos</button>
+          {storeEnabled && (
+            <Link to="/store" className="text-primary hover:text-primary font-medium">
+              Ver Todos
+            </Link>
+          )}
         </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          {featuredProducts.map((product) => (
-            <ProductCard key={product.id} product={product} />
-          ))}
-        </div>
+        {storeEnabled ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {featuredProducts.map((product) => (
+              <ProductCard key={product.id} product={product} />
+            ))}
+          </div>
+        ) : (
+          <ComingSoon
+            title="Em breve"
+            description="Nossa loja de produtos estará disponível em breve."
+          />
+        )}
       </section>
 
     </div>
   );
 };
-
 export default Dashboard;

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -3,6 +3,8 @@ import { Heart, Play, ShoppingBag } from 'lucide-react';
 import VideoCard from '../components/Videos/VideoCard';
 import ProductCard from '../components/Products/ProductCard';
 import { useFavoritesStore } from '../stores/favoritesStore';
+import ComingSoon from '../components/Common/ComingSoon';
+import { storeEnabled } from '../lib/config';
 
 const Favorites: React.FC = () => {
   const { favoriteVideos, favoriteProducts } = useFavoritesStore();
@@ -10,7 +12,9 @@ const Favorites: React.FC = () => {
 
   const tabs = [
     { id: 'videos', label: 'Vídeos', icon: Play, count: favoriteVideos.length },
-    { id: 'products', label: 'Produtos', icon: ShoppingBag, count: favoriteProducts.length }
+    ...(storeEnabled
+      ? [{ id: 'products', label: 'Produtos', icon: ShoppingBag, count: favoriteProducts.length }]
+      : [])
   ];
 
   return (
@@ -72,28 +76,31 @@ const Favorites: React.FC = () => {
         )}
 
         {activeTab === 'products' && (
-          <div>
-            {favoriteProducts.length > 0 ? (
-              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-                {favoriteProducts.map((product) => (
-                  <ProductCard key={product.id} product={product} />
-                ))}
-              </div>
-            ) : (
-              <div className="text-center py-12">
-                <ShoppingBag className="w-16 h-16 text-slate-600 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-white mb-2">Nenhum produto favorito ainda</h3>
-                <p className="text-slate-400 mb-4">Comece a comprar e adicione produtos aos seus favoritos</p>
-                <button className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-lg font-medium transition-colors">
-                  Explorar Produtos
-                </button>
-              </div>
-            )}
-          </div>
+          storeEnabled ? (
+            <div>
+              {favoriteProducts.length > 0 ? (
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+                  {favoriteProducts.map((product) => (
+                    <ProductCard key={product.id} product={product} />
+                  ))}
+                </div>
+              ) : (
+                <div className="text-center py-12">
+                  <ShoppingBag className="w-16 h-16 text-slate-600 mx-auto mb-4" />
+                  <h3 className="text-lg font-medium text-white mb-2">Nenhum produto favorito ainda</h3>
+                  <p className="text-slate-400 mb-4">Comece a comprar e adicione produtos aos seus favoritos</p>
+                  <button className="bg-emerald-600 hover:bg-emerald-700 text-white px-6 py-3 rounded-lg font-medium transition-colors">
+                    Explorar Produtos
+                  </button>
+                </div>
+              )}
+            </div>
+          ) : (
+            <ComingSoon title="Produtos em Breve" description="Você poderá favoritar produtos em breve." />
+          )
         )}
       </div>
     </div>
   );
 };
-
 export default Favorites;

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -6,12 +6,23 @@ import { mockProducts } from '../data/mockData';
 import type { Product } from '../stores/cartStore';
 import AppCard from '../components/Apps/AppCard';
 import { apps } from '../data/apps';
+import ComingSoon from '../components/Common/ComingSoon';
+import { storeEnabled } from '../lib/config';
 
 const Store: React.FC = () => {
   const [activeTab, setActiveTab] = useState<'products' | 'apps'>('products');
   const [selectedCategory, setSelectedCategory] = useState('Todos');
   const [sortBy, setSortBy] = useState('name');
   const [selectedProduct, setSelectedProduct] = useState(null as Product | null);
+
+  if (!storeEnabled) {
+    return (
+      <ComingSoon
+        title="Loja em Breve"
+        description="Nossos produtos e aplicativos estarão disponíveis em breve."
+      />
+    );
+  }
 
   const categories = ['Todos', 'Suplementos', 'Equipamentos', 'Vitaminas', 'Bem-estar', 'Recuperação'];
   const sortOptions = [

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -11,6 +11,7 @@ interface ImportMetaEnv {
   readonly VITE_PAYMENT_URL?: string;
   readonly VITE_ADMIN_EMAIL?: string;
   readonly VITE_BYPASS_PLAN_GUARD?: string;
+  readonly VITE_STORE_ENABLED?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- show a generic ComingSoon component when store features are disabled
- gate store pages and products with config flag
- update dashboard and favorites to handle missing store
- disable store menu item in sidebar
- document environment variable for store enablement

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686ef5e62f7883328cfb719e3b05b8f4