### PR TITLE
Fix regex syntax error in SQL injection validation

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -49,7 +49,7 @@ export const containsSQLInjection = (input: string): boolean => {
   
   const sqlPatterns = [
     /(\b(SELECT|INSERT|UPDATE|DELETE|DROP|CREATE|ALTER|EXEC|UNION)\b)/gi,
-    /('|(\\')|(;)|(--)|(\|\|)/gi,
+    /('|(\\')|(;)|(--)|(\|\|))/gi,
     /(\b(OR|AND)\b\s*\d+\s*=\s*\d+)/gi,
     /(\b(OR|AND)\b\s*['"][\w\s]*['"]?\s*=\s*['"][\w\s]*['"]?)/gi,
   ];


### PR DESCRIPTION
## Purpose
The user requested to fix errors in the codebase. Based on the conversation, they identified issues that needed to be corrected and provided Supabase configuration details for the project context.

## Code changes
Fixed a regex syntax error in the SQL injection validation function by adding a missing closing parenthesis in the second pattern of the `sqlPatterns` array. The regex pattern `/('|(\\')|(;)|(--)|(\|\|)/gi` was corrected to `/('|(\\')|(;)|(--)|(\|\|))/gi` to properly close the grouping.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 76`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3bc5b9e76e71486ca2d1a936fea64aae/quantum-zone)

👀 [Preview Link](https://3bc5b9e76e71486ca2d1a936fea64aae-quantum-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3bc5b9e76e71486ca2d1a936fea64aae</projectId>-->
<!--<branchName>quantum-zone</branchName>-->